### PR TITLE
feat(midstream)!: bytes::Bytes hot path (ADR-0006) — drop per-chunk String allocs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,8 @@ eventsource-stream = "0.2"
 tokio-stream = "0.1"
 dotenv = "0.15"
 async-stream = "0.3"
+# Zero-copy buffers on the streaming hot path (ADR-0006).
+bytes = "1"
 # Lean Agentic dependencies
 thiserror = "2.0"
 dashmap = "6.1"

--- a/examples/lean_agentic_streaming.rs
+++ b/examples/lean_agentic_streaming.rs
@@ -13,29 +13,30 @@ use midstream::{
     LeanAgenticSystem, LeanAgenticConfig, AgentContext,
     Midstream, HyprSettings, HyprServiceImpl, StreamProcessor, LLMClient,
 };
+use bytes::Bytes;
 use futures::stream::{BoxStream, iter};
 use tokio;
 
 /// Example LLM client that simulates streaming responses
 struct SimulatedLLMClient {
-    messages: Vec<String>,
+    messages: Vec<Bytes>,
 }
 
 impl SimulatedLLMClient {
     fn new() -> Self {
         Self {
             messages: vec![
-                "Hello! I can help you with weather information.".to_string(),
-                "Let me learn your preferences.".to_string(),
-                "What would you like to know?".to_string(),
-                "I'm getting better at understanding you!".to_string(),
+                Bytes::from_static(b"Hello! I can help you with weather information."),
+                Bytes::from_static(b"Let me learn your preferences."),
+                Bytes::from_static(b"What would you like to know?"),
+                Bytes::from_static(b"I'm getting better at understanding you!"),
             ],
         }
     }
 }
 
 impl LLMClient for SimulatedLLMClient {
-    fn stream(&self) -> BoxStream<'static, String> {
+    fn stream(&self) -> BoxStream<'static, Bytes> {
         Box::pin(iter(self.messages.clone()))
     }
 }
@@ -80,11 +81,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut context = AgentContext::new("session_001".to_string());
 
     for (i, msg) in messages.iter().enumerate() {
-        println!("  Message #{}: {}", i + 1, msg.content);
+        // Lift the chunk's bytes to UTF-8 for downstream APIs that still
+        // expect &str / String. The Bytes handle itself remains zero-copy
+        // inside the streaming pipeline; this allocation is example-only.
+        let chunk = msg.content_str();
+        println!("  Message #{}: {}", i + 1, chunk);
 
         // Process with lean agentic system
         let result = lean_system.process_stream_chunk(
-            &msg.content,
+            &chunk,
             context.clone(),
         ).await?;
 
@@ -93,7 +98,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("    → Verified: {}", if result.verified { "✓" } else { "✗" });
 
         // Update context
-        context.add_message(msg.content.clone());
+        context.add_message(chunk.into_owned());
         println!();
     }
 

--- a/examples/openrouter.rs
+++ b/examples/openrouter.rs
@@ -1,4 +1,5 @@
 use midstream::{Midstream, HyprSettings, HyprServiceImpl, StreamProcessor, LLMClient};
+use bytes::Bytes;
 use futures::stream::{BoxStream, StreamExt};
 use reqwest::Client;
 use serde_json::{json, Value};
@@ -21,7 +22,7 @@ impl OpenRouterClient {
 }
 
 impl LLMClient for OpenRouterClient {
-    fn stream(&self) -> BoxStream<'static, String> {
+    fn stream(&self) -> BoxStream<'static, Bytes> {
         let prompt = "Tell me a short story about a robot learning to paint. Make it emotional and stream it word by word.".to_string();
         let client = self.client.clone();
         let api_key = self.api_key.clone();
@@ -91,8 +92,11 @@ impl LLMClient for OpenRouterClient {
                 });
 
             while let Some(s) = stream.next().await {
-                if !s.is_empty() {
-                    yield s.trim().to_string();
+                let trimmed = s.trim();
+                if !trimmed.is_empty() {
+                    // One allocation per non-empty token; the resulting Bytes
+                    // flows through the pipeline by Arc-clone after this point.
+                    yield Bytes::copy_from_slice(trimmed.as_bytes());
                 }
             }
         })
@@ -130,7 +134,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     
     println!("\nFinal story:");
     for msg in &messages {
-        print!("{}", msg.content);
+        print!("{}", msg.content_str());
     }
     println!("\n");
     

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,4 +1,5 @@
 use midstream::{Midstream, HyprSettings, HyprServiceImpl, StreamProcessor, LLMClient};
+use bytes::Bytes;
 use futures::stream::BoxStream;
 use futures::stream::iter;
 use std::time::Duration;
@@ -7,11 +8,11 @@ use std::time::Duration;
 struct ExampleLLMClient;
 
 impl LLMClient for ExampleLLMClient {
-    fn stream(&self) -> BoxStream<'static, String> {
+    fn stream(&self) -> BoxStream<'static, Bytes> {
         Box::pin(iter(vec![
-            "URGENT: What's the weather like?".to_string(),
-            "Schedule a meeting for tomorrow".to_string(),
-            "Just a normal message".to_string(),
+            Bytes::from_static(b"URGENT: What's the weather like?"),
+            Bytes::from_static(b"Schedule a meeting for tomorrow"),
+            Bytes::from_static(b"Just a normal message"),
         ]))
     }
 }
@@ -37,7 +38,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let messages = midstream.process_stream().await?;
     println!("\nProcessed messages:");
     for msg in &messages {
-        println!("- Content: {}", msg.content);
+        println!("- Content: {}", msg.content_str());
         println!("  Intent: {:?}", msg.intent);
         if let Some(response) = &msg.tool_response {
             println!("  Tool Response: {}", response);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,19 +7,20 @@
 //! 
 //! ```rust,no_run
 //! use midstream::{Midstream, HyprSettings, HyprServiceImpl, StreamProcessor, LLMClient};
+//! use bytes::Bytes;
 //! use futures::stream::BoxStream;
 //! use futures::stream::iter;
 //! use std::time::Duration;
-//! 
+//!
 //! // Example LLM client implementation
 //! struct ExampleLLMClient;
-//! 
+//!
 //! impl LLMClient for ExampleLLMClient {
-//!     fn stream(&self) -> BoxStream<'static, String> {
+//!     fn stream(&self) -> BoxStream<'static, Bytes> {
 //!         Box::pin(iter(vec![
-//!             "Processing".to_string(),
-//!             "the".to_string(),
-//!             "stream".to_string(),
+//!             Bytes::from_static(b"Processing"),
+//!             Bytes::from_static(b"the"),
+//!             Bytes::from_static(b"stream"),
 //!         ]))
 //!     }
 //! }

--- a/src/midstream.rs
+++ b/src/midstream.rs
@@ -1,6 +1,8 @@
+use std::borrow::Cow;
 use std::sync::Arc;
 use std::time::Duration;
 use async_trait::async_trait;
+use bytes::Bytes;
 use futures::stream::BoxStream;
 use tokio::sync::Mutex;
 use serde::{Serialize, Deserialize};
@@ -34,12 +36,27 @@ pub enum Intent {
     None,
 }
 
+/// A single chunk pulled from the LLM stream.
+///
+/// The `content` field is a [`Bytes`] handle so successive chunks share the
+/// underlying allocation owned by the transport layer (per ADR-0006). Use
+/// [`LLMMessage::content_str`] to lift the bytes into UTF-8 when needed.
 #[derive(Debug, Clone)]
 pub struct LLMMessage {
-    pub content: String,
+    pub content: Bytes,
     pub timestamp: chrono::DateTime<chrono::Utc>,
     pub intent: Option<Intent>,
     pub tool_response: Option<String>,
+}
+
+impl LLMMessage {
+    /// Lift the byte content into UTF-8.
+    ///
+    /// Invalid UTF-8 sequences are replaced with U+FFFD; no allocation occurs
+    /// when the content is already valid UTF-8.
+    pub fn content_str(&self) -> Cow<'_, str> {
+        String::from_utf8_lossy(&self.content)
+    }
 }
 
 #[async_trait]
@@ -49,8 +66,16 @@ pub trait StreamProcessor {
     async fn get_average_sentiment(&self, window: Duration) -> Result<f64, Box<dyn std::error::Error>>;
 }
 
+/// Source of LLM token chunks.
+///
+/// Per ADR-0006, the stream yields [`Bytes`] handles rather than owned
+/// `String`s so the streaming pipeline can pass token chunks through the
+/// system without per-chunk heap allocation. Implementations targeting
+/// transports that already produce `Bytes` (`reqwest`, `quinn`, codec-based
+/// frames) can forward those handles directly; implementations that hold
+/// `String` data can use `Bytes::from(s.into_bytes())`.
 pub trait LLMClient: Send + Sync {
-    fn stream(&self) -> BoxStream<'static, String>;
+    fn stream(&self) -> BoxStream<'static, Bytes>;
 }
 
 #[async_trait]
@@ -112,44 +137,53 @@ impl Midstream {
         content.to_uppercase().starts_with("URGENT")
     }
 
-    async fn process_message(&self, content: String) -> Result<LLMMessage, Box<dyn std::error::Error>> {
+    async fn process_message(&self, content: Bytes) -> Result<LLMMessage, Box<dyn std::error::Error>> {
         // Validate content
         if content.is_empty() {
             return Err("Empty message content".into());
         }
 
         let timestamp = chrono::Utc::now();
-        let intent = self.detect_intent(&content);
+        // Lift the byte content to UTF-8 once for intent / urgent classification.
+        // `from_utf8_lossy` borrows when input is already valid UTF-8.
+        let content_str = String::from_utf8_lossy(&content);
+        let intent = self.detect_intent(&content_str);
+        let urgent = self.is_urgent(&content_str);
         let mut tool_response = None;
 
         // Handle urgent requests immediately
-        if self.is_urgent(&content) && intent != Intent::None {
+        if urgent && intent != Intent::None {
             if let Some(tool) = &self.tool_integration {
                 tool_response = match intent {
-                    Intent::Weather => Some(tool.handle_weather_intent(&content)?),
-                    Intent::Calendar => Some(tool.handle_calendar_intent(&content)?),
+                    Intent::Weather => Some(tool.handle_weather_intent(&content_str)?),
+                    Intent::Calendar => Some(tool.handle_calendar_intent(&content_str)?),
                     Intent::None => None,
                 };
             }
         }
 
-        let message = LLMMessage { 
-            content, 
+        // Capture metric fields that need the byte handle before we move it.
+        let content_len = content.len();
+        drop(content_str);
+
+        let message = LLMMessage {
+            content,
             timestamp,
             intent: Some(intent),
             tool_response,
         };
 
-        // Create and ingest metric
+        // Create and ingest metric. (MetricRecord shape is unchanged by ADR-0006;
+        // its per-chunk allocations are the subject of a follow-up ADR.)
         let metric = MetricRecord {
             timestamp: timestamp.timestamp() as u64,
             name: "llm_stream".to_string(),
-            value: message.content.len() as f64,
+            value: content_len as f64,
             labels: vec![
                 ("type".to_string(), "message".to_string()),
-                ("size".to_string(), message.content.len().to_string()),
+                ("size".to_string(), content_len.to_string()),
                 ("intent".to_string(), format!("{:?}", message.intent)),
-                ("urgent".to_string(), self.is_urgent(&message.content).to_string()),
+                ("urgent".to_string(), urgent.to_string()),
             ],
         };
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -2,6 +2,7 @@
 mod tests {
     use crate::midstream::{Midstream, StreamProcessor, Intent, LLMClient, HyprService, ToolIntegration, MetricRecord, TimeWindow, AggregateFunction};
     use std::time::Duration;
+    use bytes::Bytes;
     use mockall::*;
     use futures::stream::{self, BoxStream};
 
@@ -10,7 +11,7 @@ mod tests {
     mock! {
         pub LLMClient {}
         impl LLMClient for LLMClient {
-            fn stream(&self) -> BoxStream<'static, String>;
+            fn stream(&self) -> BoxStream<'static, Bytes>;
         }
     }
 
@@ -39,9 +40,9 @@ mod tests {
             .times(1)
             .return_once(move || {
                 Box::pin(stream::iter(vec![
-                    "Process".to_string(),
-                    "this".to_string(),
-                    "stream".to_string(),
+                    Bytes::from_static(b"Process"),
+                    Bytes::from_static(b"this"),
+                    Bytes::from_static(b"stream"),
                 ]))
             });
 
@@ -91,7 +92,7 @@ mod tests {
         mock_llm.expect_stream()
             .times(1)
             .return_once(|| {
-                Box::pin(stream::iter(vec!["test message".to_string()]))
+                Box::pin(stream::iter(vec![Bytes::from_static(b"test message")]))
             });
 
         let midstream = Midstream::new(
@@ -112,7 +113,7 @@ mod tests {
         mock_llm.expect_stream()
             .times(1)
             .return_once(|| {
-                Box::pin(stream::iter(Vec::<String>::new()))
+                Box::pin(stream::iter(Vec::<Bytes>::new()))
             });
 
         let midstream = Midstream::new(
@@ -130,11 +131,11 @@ mod tests {
         let mut mock_llm = MockLLMClient::new();
         let mut mock_hypr = MockHyprService::new();
         
-        let large_message = "x".repeat(1_000_000);
+        let large_message = Bytes::from(vec![b'x'; 1_000_000]);
         mock_llm.expect_stream()
             .times(1)
             .return_once(move || {
-                Box::pin(stream::iter(vec![large_message.clone()]))
+                Box::pin(stream::iter(vec![large_message]))
             });
 
         mock_hypr.expect_ingest_metric()
@@ -163,7 +164,7 @@ mod tests {
             .times(1)
             .return_once(|| {
                 Box::pin(stream::iter(vec![
-                    "URGENT: What's the weather".to_string(),
+                    Bytes::from_static(b"URGENT: What's the weather"),
                 ]))
             });
 
@@ -196,7 +197,7 @@ mod tests {
         mock_llm.expect_stream()
             .times(1)
             .return_once(|| {
-                Box::pin(stream::iter(vec!["".to_string()]))
+                Box::pin(stream::iter(vec![Bytes::new()]))
             });
 
         let midstream = Midstream::new(


### PR DESCRIPTION
## Summary

Implements [ADR-0006](docs/adr/0006-zero-copy-bytes-streaming.md) (currently
on the `adr/deep-review-and-sota-roadmap` branch from PR #6): replaces the
per-token `String` allocations on the LLM streaming hot path with
`bytes::Bytes` handles that flow through the pipeline by Arc-clone instead
of per-chunk heap allocation.

**Semver-major** on the `midstream` crate (0.1.0 → 0.2.0). Touches 7 files,
+96 / -48.

## What changed

### Public API breaks

| Before | After |
|---|---|
| `LLMMessage.content: String` | `LLMMessage.content: Bytes` |
| `LLMClient::stream() -> BoxStream<'static, String>` | `LLMClient::stream() -> BoxStream<'static, Bytes>` |
| `Midstream::process_message(content: String)` | `Midstream::process_message(content: Bytes)` |

### New API

- `LLMMessage::content_str(&self) -> Cow<'_, str>` — lossy UTF-8 lift for
  callers that still want `&str`. Returns `Cow::Borrowed` (no alloc) when
  the content is valid UTF-8.

### Migration

| Input | Replacement |
|---|---|
| `"...".to_string()` literal | `Bytes::from_static(b"...")` (zero alloc) |
| `String` from caller | `Bytes::from(s.into_bytes())` (zero alloc; moves the buffer) |
| `&str` slice | `Bytes::copy_from_slice(s.as_bytes())` (one alloc; was unavoidable) |
| Reading from message: `msg.content` | `msg.content_str()` for display / parsing; raw `&msg.content` for `len()`, `is_empty()`, `Bytes` ops |

## Why now (vs other ADR-0006 work)

This PR is the **minimum semver-major break** that opens the door to the
rest of the hot-path work. `MetricRecord`'s per-chunk label allocations
(roughly 5 extra `String`s per chunk) are intentionally left for a
follow-up — those are a smaller per-chunk win and don't require an API
break. Doing them in this PR would have grown the blast radius without
proportional payoff.

## Build status

| Target | Status | Notes |
|---|---|---|
| `cargo check -p midstreamer-temporal-compare` | ✅ clean | |
| `cargo check -p midstreamer-scheduler` | ✅ clean | |
| `cargo check --workspace --exclude midstream --exclude hyprstream` | ✅ clean | all 6 published workspace crates compile |
| `cargo check -p midstream` | ❌ **pre-existing failure** | 12 errors inside `hyprstream-main/src/storage/adbc.rs` from `arrow-schema 53 vs 54` skew via `duckdb`. None of those errors are touched by this PR. → [ADR-0002](docs/adr/0002-unvendor-hyprstream.md) / [ADR-0014](docs/adr/0014-supply-chain-pinning.md) |

The hyprstream-main vendored crate's build failure is **on the publish
critical path** and must be cleared (un-vendor or feature-gate) before
midstream 0.2.0 can `cargo publish`. That's a separate PR.

## What this enables

Per [ADR-0006](docs/adr/0006-zero-copy-bytes-streaming.md):

- Transport-layer buffers (reqwest's `Bytes`, quinn's `Bytes`, codec
  `BytesMut`) now pass through the pipeline without re-allocation.
- One allocation per *stream*, not one per *token*. Each chunk is an
  `Arc::clone` of an existing buffer plus a slice index.
- Cache keys in `crates/temporal-compare` (the second ADR-0006 follow-up)
  can switch from `format!("...")` to `u64` xxhash3 of the slice without
  needing this break.

## Test plan

- [x] All 6 workspace `midstreamer-*` crates type-check.
- [x] `cargo check -p midstream` failures are confirmed pre-existing
      (`git stash && cargo check -p midstream` produces the same 12
      errors from `hyprstream-main/src/storage/adbc.rs:836`).
- [x] All test fixtures in `src/tests/mod.rs` updated to use `Bytes`.
- [x] Display sites lift via `content_str()` — no `Bytes`-Display panic.
- [ ] Run `cargo test -p midstream --lib` once hyprstream-main build is unblocked (gating ADR).
- [ ] Add a `dhat` or `stats_alloc` bench measuring allocations per chunk before/after (ADR-0006 implementation note; deferred to the metric-record cleanup PR).

## Not in this PR (follow-ups)

1. `MetricRecord` label cleanup (`name: &'static str`; tag keys static).
2. `crates/temporal-compare` cache key migration (`format!` → `u64` xxhash3).
3. Window-slice `to_vec()` → `Bytes::slice()` in `temporal-compare`.
4. Allocation regression bench harness (`stats_alloc` / `dhat`).
5. Unblock `cargo check -p midstream` by un-vendoring `hyprstream-main`
   (ADR-0002) or feature-gating it.

## Stacking

This PR depends on PR #6 (ADRs) only conceptually — ADR-0006 lives on that
branch. Either:
- Merge PR #6 first, then this rebases cleanly onto main, or
- Land this against the same `adr/deep-review-and-sota-roadmap` branch.

I left this on `feat/bytes-hot-path-adr0006` off `main` so reviewers can
see *just the code change* with the audit-doc PR as separate context.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)