### PR TITLE
chore: declare MSRV = 1.81 across the workspace + CI gate (ADR-0023)

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -46,6 +46,38 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+  # MSRV (Minimum Supported Rust Version) check per ADR-0023.
+  # Every published crate declares rust-version = "1.81"; this job
+  # proves the workspace still compiles + tests on that toolchain so
+  # the declared MSRV doesn't quietly drift forward. --locked is
+  # mandatory: an unlocked update could pull a transitive dep that
+  # requires newer rustc, masking the MSRV check.
+  msrv:
+    name: MSRV (1.81)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust 1.81 toolchain
+        uses: dtolnay/rust-toolchain@1.81
+
+      - name: Setup cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "msrv-1.81"
+
+      - name: cargo check (workspace, locked)
+        # Exclude `midstream` and `hyprstream` while ADR-0002 / ADR-0014
+        # un-vendoring is in flight: those two crates currently fail to
+        # build on any toolchain due to arrow-schema version skew via
+        # the vendored hyprstream-main. Re-include both once ADR-0002
+        # lands. The 6 published `midstreamer-*` crates plus the WASM
+        # bindings are covered.
+        run: cargo check --workspace --exclude midstream --exclude hyprstream --locked
+
+      - name: cargo test --lib (workspace, locked)
+        run: cargo test --workspace --exclude midstream --exclude hyprstream --lib --locked
+
   # Build and test matrix
   test:
     name: Test (${{ matrix.os }}, ${{ matrix.rust }})
@@ -259,6 +291,7 @@ jobs:
     needs:
       - format
       - clippy
+      - msrv
       - test
       - build-crates
       - wasm

--- a/AIMDS/Cargo.toml
+++ b/AIMDS/Cargo.toml
@@ -10,6 +10,7 @@ resolver = "2"
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.81"
 authors = ["AIMDS Team"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/your-org/aimds"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ exclude = ["npm-wasm"]
 name = "midstream"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.81"
 description = "Real-time LLM streaming with inflight analysis"
 
 [dependencies]

--- a/crates/nanosecond-scheduler/Cargo.toml
+++ b/crates/nanosecond-scheduler/Cargo.toml
@@ -2,6 +2,7 @@
 name = "midstreamer-scheduler"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.81"
 description = "Ultra-low-latency real-time task scheduler"
 license = "MIT"
 repository = "https://github.com/ruvnet/midstream"

--- a/crates/quic-multistream/Cargo.toml
+++ b/crates/quic-multistream/Cargo.toml
@@ -2,6 +2,7 @@
 name = "midstreamer-quic"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.81"
 description = "QUIC multi-stream support for native and WASM targets"
 license = "MIT"
 repository = "https://github.com/ruvnet/midstream"

--- a/crates/strange-loop/Cargo.toml
+++ b/crates/strange-loop/Cargo.toml
@@ -2,6 +2,7 @@
 name = "midstreamer-strange-loop"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.81"
 description = "Self-referential systems and meta-learning"
 license = "MIT"
 repository = "https://github.com/ruvnet/midstream"

--- a/crates/temporal-attractor-studio/Cargo.toml
+++ b/crates/temporal-attractor-studio/Cargo.toml
@@ -2,6 +2,7 @@
 name = "midstreamer-attractor"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.81"
 description = "Dynamical systems and strange attractors analysis"
 license = "MIT"
 repository = "https://github.com/ruvnet/midstream"

--- a/crates/temporal-compare/Cargo.toml
+++ b/crates/temporal-compare/Cargo.toml
@@ -2,6 +2,7 @@
 name = "midstreamer-temporal-compare"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.81"
 description = "Temporal sequence comparison and pattern matching"
 license = "MIT"
 repository = "https://github.com/ruvnet/midstream"

--- a/crates/temporal-neural-solver/Cargo.toml
+++ b/crates/temporal-neural-solver/Cargo.toml
@@ -2,6 +2,7 @@
 name = "midstreamer-neural-solver"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.81"
 description = "Temporal logic with neural reasoning"
 license = "MIT"
 repository = "https://github.com/ruvnet/midstream"

--- a/npm-wasm/Cargo.toml
+++ b/npm-wasm/Cargo.toml
@@ -3,6 +3,7 @@ name = "midstream-wasm"
 version = "1.0.0"
 authors = ["Midstream Contributors"]
 edition = "2021"
+rust-version = "1.81"
 description = "WebAssembly bindings for Midstream temporal comparison, scheduling, and meta-learning"
 license = "MIT"
 repository = "https://github.com/midstream/midstream"

--- a/wasm-bindings/Cargo.toml
+++ b/wasm-bindings/Cargo.toml
@@ -2,6 +2,7 @@
 name = "midstream-wasm"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.81"
 description = "WASM bindings for MidStream Lean Agentic Learning System"
 
 [lib]

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lean-agentic-wasm"
 version = "1.0.0"
 edition = "2021"
+rust-version = "1.81"
 description = "WASM bindings for Lean Agentic Learning System with WebSocket and SSE support"
 
 [lib]


### PR DESCRIPTION
## Summary

Implements [ADR-0023](docs/adr/0023-msrv-policy.md): every published
crate now declares `rust-version = "1.81"` and a CI job verifies the
declared MSRV stays buildable across PRs.

**Metadata + CI only. No source code touched.** 12 files, +44 / -0.

## Why this matters for publishing

Before this PR, `cargo publish` would publish crates that floated on
"whatever rustc the publisher happened to have installed." Downstream
consumers on older toolchains hit `rustc` errors deep in the code with
no pre-emptive `error: package requires Rust X.Y` message. This PR
closes that hole.

## What changed

### Manifest declarations (11 files, +1 line each)

Each of the workspace's `[package]` blocks gains `rust-version = "1.81"`.
`AIMDS/Cargo.toml`'s `[workspace.package]` declares it so its four
child crates inherit. Coverage:

| Manifest | MSRV |
|---|---|
| `Cargo.toml` (root) | 1.81 |
| `crates/temporal-compare/Cargo.toml` | 1.81 |
| `crates/strange-loop/Cargo.toml` | 1.81 |
| `crates/temporal-neural-solver/Cargo.toml` | 1.81 |
| `crates/nanosecond-scheduler/Cargo.toml` | 1.81 |
| `crates/quic-multistream/Cargo.toml` | 1.81 |
| `crates/temporal-attractor-studio/Cargo.toml` | 1.81 |
| `wasm/Cargo.toml` | 1.81 |
| `wasm-bindings/Cargo.toml` | 1.81 |
| `npm-wasm/Cargo.toml` | 1.81 |
| `AIMDS/Cargo.toml [workspace.package]` | 1.81 (inherited by 4 aimds-* crates) |

### CI gate (`.github/workflows/rust-ci.yml`)

New `msrv` job between `clippy` and `test`:

```yaml
msrv:
  name: MSRV (1.81)
  runs-on: ubuntu-latest
  steps:
    - uses: actions/checkout@v4
    - uses: dtolnay/rust-toolchain@1.81
    - uses: Swatinem/rust-cache@v2 with: { shared-key: "msrv-1.81" }
    - run: cargo check --workspace --exclude midstream --exclude hyprstream --locked
    - run: cargo test --workspace --exclude midstream --exclude hyprstream --lib --locked
```

- `--locked` is mandatory — an unlocked update could pull a newer
  transitive that requires newer rustc, masking the MSRV check.
- `midstream` + `hyprstream` are temporarily excluded; both currently
  fail to build on any toolchain due to the pre-existing arrow-schema
  version skew inside vendored `hyprstream-main/` (tracked by ADRs
  0002 / 0014). Re-include both once ADR-0002 lands.
- Added to `ci-success` aggregator's `needs:` list so PRs cannot merge
  without the MSRV check passing.

## Rationale for 1.81 (not the latest stable 1.95)

- Conservative ~14 minor versions behind stable. ADR-0023 specifies
  "N-3 minor releases" with quarterly review.
- Released 2024-10-17, so Debian stable / RHEL / Amazon Linux 2023+ /
  Ubuntu 24.04 all carry it.
- Clears every modern-Rust feature the codebase uses today:
  - async-fn-in-trait (stable since 1.75)
  - GAT-based patterns (1.65+)
  - LazyLock (1.80+)
  - tuple-struct field defaults (n/a)
- No language-level feature in the current code requires anything
  newer. ADR-0023's bump policy (minor crate-version bump + ADR)
  applies if we ever need to raise this.

## Bump policy (per ADR-0023)

- **Bumping MSRV is a minor-version bump on the affected crate.**
- **MSRV bumps require an ADR** that names the reason.
- **At most quarterly cadence**; re-evaluate even when not bumping.

## Build verification

| Command | Result |
|---|---|
| `cargo check --workspace --exclude midstream --exclude hyprstream` | ✅ clean (host rustc 1.95) |
| All 11 manifests parsed by cargo | ✅ |
| `grep -c '^rust-version' Cargo.toml crates/*/Cargo.toml wasm*/Cargo.toml npm-wasm/Cargo.toml AIMDS/Cargo.toml` | 11 |
| Working tree | clean (no `.claude/*` leaks) |

The CI job will actually run on toolchain 1.81 once this PR triggers
the workflow. Local rustc here is 1.95.0 (2026-04-14); the local
`cargo check` only proves syntactic validity of the manifest changes.

## Stacking

Independent of PRs #6 (ADRs), #7 (bytes), #8 (TLS), #9 (licence),
#10 (cargo-deny). Can merge in any order.

## Test plan

- [x] Every `[package]` in the workspace declares `rust-version`.
- [x] `cargo check --workspace` clean on the buildable subset.
- [x] CI job added to `ci-success.needs`.
- [ ] After merge: confirm the `msrv` job runs and passes on a
      follow-up PR.
- [ ] Quarterly: re-evaluate MSRV per ADR-0023 (next review:
      2026-08-13).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)