### PR TITLE
chore(governance): CONTRIBUTING, CoC, SECURITY, CODEOWNERS, templates, dependabot (ADR-0039)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,46 @@
+# CODEOWNERS — automatic review routing.
+#
+# Lines are matched in order; the LAST matching pattern wins. So put
+# broadest patterns first and most-specific last. Documented at:
+# https://docs.github.com/en/repositories/managing-your-repositories-settings-and-security/customizing-your-repository/about-code-owners
+#
+# All teams currently resolve to @ruv. As the maintainer set grows
+# (per GOVERNANCE.md), entries here split into real teams.
+
+# Default owner — every file the more-specific patterns below don't claim.
+*                                       @ruv
+
+# ----- Architectural decisions -----
+# Every change to an ADR or the ADR index needs the maintainer's eyes.
+/docs/adr/                              @ruv
+
+# ----- Security-sensitive surface -----
+# QUIC transport — TLS-touching code (cf. ADR-0011).
+/crates/quic-multistream/               @ruv
+# AIMDS — the AI manipulation defense subsystem.
+/AIMDS/                                 @ruv
+# Supply-chain policy.
+/deny.toml                              @ruv
+/.github/workflows/audit.yml            @ruv
+
+# ----- Hot-path crates -----
+# The scheduler's "sub-microsecond" claim has an SLO contract
+# (ADR-0033) — any change here needs a perf-aware review.
+/crates/nanosecond-scheduler/           @ruv
+# Temporal comparator — DTW / LCS / edit-distance hot path.
+/crates/temporal-compare/               @ruv
+
+# ----- CI / release machinery -----
+/.github/workflows/                     @ruv
+/.github/                               @ruv
+
+# ----- Top-level governance + licence -----
+/CODE_OF_CONDUCT.md                     @ruv
+/CONTRIBUTING.md                        @ruv
+/GOVERNANCE.md                          @ruv
+/SECURITY.md                            @ruv
+/LICENSE-MIT                            @ruv
+/LICENSE-APACHE                         @ruv
+/NOTICE                                 @ruv
+/CODEOWNERS                             @ruv
+/.github/CODEOWNERS                     @ruv

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,76 @@
+name: "🐛 Bug report"
+description: Report a defect in midstream.
+title: "[bug]: "
+labels: [bug, needs-triage]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. Please fill in the form below — the
+        more reproducible the report, the faster we can act.
+
+        **Security issues do not go here.** See [SECURITY.md](../../SECURITY.md).
+  - type: input
+    id: crate
+    attributes:
+      label: Affected crate(s)
+      description: Which crate(s) does this bug affect? Multiple is fine.
+      placeholder: "e.g. midstreamer-quic, midstreamer-temporal-compare"
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version (or git SHA)
+      description: From `cargo tree` or your `Cargo.toml`.
+      placeholder: "0.1.0 / git SHA abc1234"
+    validations:
+      required: true
+  - type: input
+    id: rustc
+    attributes:
+      label: rustc version
+      description: Output of `rustc --version`.
+      placeholder: "rustc 1.81.0 (eeb90cda1 2024-09-04)"
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - Other (specify in repro)
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproduction
+      description: |
+        Smallest possible code / commands that show the bug. Prefer a
+        runnable snippet or a link to a public branch.
+      render: rust
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: Include error messages, panics, and full stack traces.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Logs, screenshots, related issues, workarounds.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,24 @@
+# Issue-template chooser configuration.
+#
+# `blank_issues_enabled: false` forces users to pick one of the
+# structured templates above, which keeps triage cheap.
+
+blank_issues_enabled: false
+
+contact_links:
+  - name: "🔒 Security report"
+    url: https://github.com/ruvnet/midstream/security/advisories/new
+    about: |
+      DO NOT open a public issue for security reports. Use GitHub
+      Security Advisories (link above) or email security@ruv.net.
+      Full policy in SECURITY.md.
+  - name: "💬 Question or discussion"
+    url: https://github.com/ruvnet/midstream/discussions
+    about: |
+      Open-ended questions and design discussions belong in
+      Discussions, not Issues. Issues are for tracked work.
+  - name: "📚 Architecture Decision Records"
+    url: https://github.com/ruvnet/midstream/tree/main/docs/adr
+    about: |
+      Before requesting a large change, skim the ADRs — your idea may
+      already be captured there as accepted, deferred, or rejected.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,49 @@
+name: "✨ Feature request"
+description: Suggest an enhancement or new capability.
+title: "[feat]: "
+labels: [enhancement, needs-triage]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion. Bigger architectural changes are
+        best discussed as a draft ADR — see `docs/adr/README.md`. Use
+        this template for smaller, focused requests.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: |
+        What problem are you trying to solve? Describe the use case
+        and the gap, not the solution yet.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: |
+        How would you like midstream to behave? API sketches and
+        example call-sites are welcome.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other approaches did you weigh, and why this one?
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Suspected scope
+      options:
+        - Small (single function / one crate)
+        - Medium (one crate, public API change)
+        - Large (multiple crates / architectural — likely needs an ADR)
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Links to prior art, related issues, motivating projects.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,126 @@
+# Dependabot configuration — see ADR-0039.
+#
+# Three ecosystems live in this repo: Cargo (Rust), npm (TypeScript),
+# and GitHub Actions. Each gets its own update schedule, grouped so
+# we don't get N separate PRs per week.
+
+version: 2
+updates:
+  # ----- Rust / Cargo -----
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:30"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "rust"
+    commit-message:
+      prefix: "chore(deps)"
+      include: scope
+    groups:
+      # Group patch-level bumps to avoid PR sprawl.
+      patch-updates:
+        applies-to: version-updates
+        update-types: ["patch"]
+      # Group minor-level updates for major dep families.
+      tokio-stack:
+        applies-to: version-updates
+        patterns:
+          - "tokio*"
+          - "tracing*"
+          - "futures*"
+      rustls-stack:
+        applies-to: version-updates
+        patterns:
+          - "rustls*"
+          - "webpki*"
+          - "quinn*"
+      serde-stack:
+        applies-to: version-updates
+        patterns:
+          - "serde*"
+    ignore:
+      # Keep the vendored hyprstream-main on whatever versions the
+      # upstream chooses — Dependabot can't reason about it usefully
+      # while ADR-0002 is in flight.
+      - dependency-name: "duckdb"
+      - dependency-name: "arrow*"
+      - dependency-name: "arrow-flight"
+      - dependency-name: "hyprstream"
+
+  # ----- AIMDS subproject (separate workspace today) -----
+  - package-ecosystem: cargo
+    directory: "/AIMDS"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "rust"
+      - "aimds"
+    commit-message:
+      prefix: "chore(aimds-deps)"
+
+  # ----- npm packages -----
+  - package-ecosystem: npm
+    directory: "/npm"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:30"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 3
+    labels: [dependencies, javascript]
+    commit-message:
+      prefix: "chore(npm-cli-deps)"
+    groups:
+      patch-updates:
+        applies-to: version-updates
+        update-types: ["patch"]
+      types:
+        applies-to: version-updates
+        patterns: ["@types/*"]
+
+  - package-ecosystem: npm
+    directory: "/npm-wasm"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 3
+    labels: [dependencies, javascript, wasm]
+    commit-message:
+      prefix: "chore(wasm-deps)"
+
+  - package-ecosystem: npm
+    directory: "/lean-agentic-js"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:30"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 3
+    labels: [dependencies, javascript]
+    commit-message:
+      prefix: "chore(lean-js-deps)"
+
+  # ----- GitHub Actions used in CI -----
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "10:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 3
+    labels: [dependencies, ci]
+    commit-message:
+      prefix: "chore(actions-deps)"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,55 @@
+<!--
+  Thanks for the PR. Fill in the sections below; delete anything that
+  doesn't apply.
+
+  Quick links:
+   - Contributing guide:  CONTRIBUTING.md
+   - ADR index:           docs/adr/README.md
+   - Security reports:    DO NOT use a PR — see SECURITY.md
+-->
+
+## Summary
+
+<!-- 1–3 sentences. What does this PR do, and why? -->
+
+## Linked ADR / issue
+
+<!--
+  If this PR implements or supersedes an ADR, cite it explicitly:
+    Implements ADR-0NNN.
+    Closes #1234.
+  If it changes a public contract, attach the ADR before requesting
+  review.
+-->
+
+## Checklist
+
+- [ ] Every commit is signed off (`git commit -s`) per the DCO.
+- [ ] Commit messages follow Conventional Commits (`feat:` / `fix:` /
+      `chore:` / …) and use `!` for breaking changes.
+- [ ] CI is green locally (`cargo check --workspace`, relevant tests).
+- [ ] Public API changes are documented and, if applicable, have a
+      semver bump per ADR-0024.
+- [ ] If this PR touches performance-sensitive paths, benches were
+      run and the numbers are in the PR description (ADR-0009).
+- [ ] If this PR touches the licence story, dependencies, or any
+      published-crate metadata, `cargo deny check` was re-run locally
+      (ADR-0014).
+- [ ] Working tree only contains changes for this PR (no unrelated
+      file deletions or moves).
+
+## Test plan
+
+<!--
+  Bullet list of what was tested and how. "Existing CI" is fine for
+  trivial mechanical changes; otherwise be specific.
+-->
+
+- [ ] …
+
+## Out of scope / follow-ups
+
+<!--
+  Anything you noticed but decided not to fix in this PR. List as
+  issues to file (or note that you already filed them).
+-->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,139 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation
+in our community a harassment-free experience for everyone, regardless
+of age, body size, visible or invisible disability, ethnicity, sex
+characteristics, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance,
+race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open,
+welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for
+our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our
+  mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or
+  political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in
+  a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our
+standards of acceptable behavior and will take appropriate and fair
+corrective action in response to any behavior that they deem
+inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit,
+or reject comments, commits, code, wiki edits, issues, and other
+contributions that are not aligned with this Code of Conduct, and will
+communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also
+applies when an individual is officially representing the community in
+public spaces. Examples of representing our community include using an
+official e-mail address, posting via an official social media account,
+or acting as an appointed representative at an online or offline
+event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior
+may be reported to the community leaders responsible for enforcement
+at **conduct@ruv.net**. All complaints will be reviewed and
+investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and
+security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in
+determining the consequences for any action they deem in violation of
+this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior
+deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders,
+providing clarity around the nature of the violation and an
+explanation of why the behavior was inappropriate. A public apology
+may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior.
+No interaction with the people involved, including unsolicited
+interaction with those enforcing the Code of Conduct, for a specified
+period of time. This includes avoiding interactions in community
+spaces as well as external channels like social media. Violating these
+terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards,
+including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or
+public communication with the community for a specified period of
+time. No public or private interaction with the people involved,
+including unsolicited interaction with those enforcing the Code of
+Conduct, is allowed during this period. Violating these terms may
+lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of
+community standards, including sustained inappropriate behavior,
+harassment of an individual, or aggression toward or disparagement of
+classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction
+within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][cc],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the
+FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations
+are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[cc]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,96 @@
+# Contributing to midstream
+
+Thanks for considering a contribution. This document is short on
+purpose: read it once, then refer back when something specific comes
+up.
+
+## Before you start
+
+1. Read the **[Architecture Decision Records](docs/adr/README.md)** —
+   they're the canonical answer to *why* the project looks the way it
+   does. Most surprising design choices are captured there. If you
+   want to challenge a decision, write a superseding ADR rather than
+   working around it.
+2. Skim the [Code of Conduct](CODE_OF_CONDUCT.md). It's the
+   Contributor Covenant — short.
+3. Security issues: see [SECURITY.md](SECURITY.md). **Do not open a
+   public issue for a security report.**
+
+## Getting set up
+
+```bash
+git clone https://github.com/ruvnet/midstream.git
+cd midstream
+
+# Verify your toolchain matches the project MSRV (1.81 per ADR-0023):
+rustc --version
+```
+
+Build / test:
+
+```bash
+# All 6 publishable workspace crates (the only fully-buildable subset
+# today; ADR-0002 will fix the root midstream crate once the vendored
+# hyprstream-main is removed).
+cargo check --workspace --exclude midstream --exclude hyprstream
+cargo test  --workspace --exclude midstream --exclude hyprstream --lib
+```
+
+## Sending a PR
+
+1. **Fork + branch.** Branch names use `<type>/<short-desc>-adr<NNNN>`
+   when implementing a specific ADR, e.g. `feat/bytes-hot-path-adr0006`.
+2. **One concern per PR.** Mechanical refactors, security fixes, and
+   feature work each get their own PR.
+3. **Commit messages** follow [Conventional Commits](https://www.conventionalcommits.org/):
+   - `feat:` / `fix:` / `chore:` / `docs:` / `refactor:` / `perf:` / `test:` / `build:` / `ci:`
+   - Append `!` for breaking changes (e.g. `feat!:` or `fix(quic)!:`).
+   - The body explains *why*; the diff shows *what*.
+4. **Every commit must include a `Signed-off-by:` trailer.** This is
+   the [Developer Certificate of Origin](https://developercertificate.org/)
+   sign-off — there is no CLA. Set it up once:
+
+   ```bash
+   git config --global user.name  "Your Name"
+   git config --global user.email "you@example.com"
+   # Then commit with -s:
+   git commit -s -m "feat: …"
+   ```
+5. **Link the ADR.** If your PR implements an ADR, cite it in the PR
+   description and in commit messages. If your PR changes a public API
+   or crosses a module boundary, *write* an ADR first.
+6. **CI must pass.** The audit + MSRV + test matrix must all be green
+   before merge. Use `cargo xtask ci` (once ADR-0037 lands) to
+   reproduce the same gates locally.
+
+## What we care about in review
+
+- **Correctness over cleverness.** Boring code is fine.
+- **Bench / measure when claiming perf.** ADR-0009 sets the bar:
+  numbers must come from criterion runs, not hand-typed prose.
+- **No silent re-licensing.** Code carries `MIT OR Apache-2.0` per
+  ADR-0036.
+- **No unwrap / expect in production code paths** (per ADR-0018).
+  Tests, examples, and benches are fine.
+- **Reverse comments to *why*, not *what*.** Well-named identifiers
+  cover the what.
+
+## Reporting bugs
+
+Use the bug report issue template. Include:
+
+- The exact crate version (and git rev if applicable).
+- Toolchain (`rustc --version`).
+- Minimal reproducer.
+- Expected vs actual behaviour.
+
+## Asking questions
+
+For project-direction discussions, file an issue with the "discussion"
+label or write a draft ADR. We don't currently have a chat channel.
+
+## License
+
+By contributing you agree your contribution is dual-licensed under MIT
+or Apache-2.0 at the user's choice (see [NOTICE](NOTICE)). The DCO
+sign-off makes this explicit on every commit.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,74 @@
+# Project Governance
+
+This document describes how midstream is currently maintained. It is
+deliberately short: the project is small, the maintainer set is
+small, and an elaborate governance document would just be wishful
+thinking.
+
+## Roles
+
+- **Maintainer.** Has merge rights on `main`. Triages issues,
+  reviews PRs, makes release calls. Today the maintainer is
+  **@ruv**.
+- **Contributor.** Anyone who has had a PR merged. Contributors get
+  reviewer assignments via `CODEOWNERS` based on the area they work
+  in.
+
+There is no "core team", no steering committee, no voting body. If
+the maintainer becomes unresponsive for 90+ days, contributors with
+substantial merge history (≥10 substantive PRs over 6+ months) may
+elect a replacement by majority vote on a public issue.
+
+## Decisions
+
+- **Architectural decisions** are captured in
+  [`docs/adr/`](docs/adr/README.md). Anything that crosses a module
+  boundary, changes a public contract, or sets a policy needs an ADR.
+  Smaller changes don't.
+- **Code changes** require a PR with at least one maintainer review,
+  passing CI, and DCO sign-off on every commit (see
+  [CONTRIBUTING.md](CONTRIBUTING.md)).
+- **Disputes about scope or direction** are resolved by:
+  1. Discussion on the relevant issue / PR.
+  2. A draft ADR if the disagreement is architectural.
+  3. Maintainer call if no consensus emerges within a week.
+
+The maintainer's call is not a veto — anyone who disagrees can fork.
+But it is a decision that ends the discussion.
+
+## Becoming a maintainer
+
+After ~10 substantive merged PRs across at least 6 months, an active
+contributor may be invited to the maintainers team. There is no
+formal application. If you think you should be a maintainer and
+haven't been invited, ask.
+
+Invited maintainers commit to:
+
+- Reviewing PRs in their area of expertise within 14 days of request.
+- Following the security disclosure process in
+  [SECURITY.md](SECURITY.md).
+- Mentoring new contributors.
+
+Maintainers can step down at any time by opening an issue.
+
+## Releases
+
+Releases are cut by the maintainer following the process in
+[ADR-0017](docs/adr/0017-release-and-publishing.md):
+`release-plz` opens a release PR; merging it publishes to crates.io
+and creates a signed GitHub release.
+
+Security releases follow the same flow but bypass the normal release
+cadence — they ship as soon as the fix is reviewed and CI is green.
+
+## Conflicts of interest
+
+If a maintainer is reviewing a PR they have a financial or personal
+stake in (e.g. it was authored by an employer's account), they should
+recuse themselves and request review from another maintainer or a
+trusted contributor.
+
+## Changing this document
+
+Update via PR. Substantive changes require an ADR.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,79 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Do not open a public GitHub issue for security reports.** Use one of
+the channels below.
+
+### Preferred: GitHub Security Advisories
+
+File a private advisory at
+<https://github.com/ruvnet/midstream/security/advisories/new>. This
+opens a private conversation with the maintainers, scoped to the
+issue, with built-in CVE coordination.
+
+### Email fallback
+
+If you can't use GitHub Security Advisories, email
+**security@ruv.net** with:
+
+- A description of the vulnerability and its impact.
+- Reproduction steps (or a proof-of-concept).
+- The affected crate name and version (or commit SHA).
+- Your suggested fix, if any.
+
+PGP-encrypted reports are accepted; key fingerprint will be published
+here once generated. For now, plain email is fine.
+
+## Response timeline
+
+| Step | Target |
+|---|---|
+| Acknowledgement of receipt | within **72 hours** |
+| Initial assessment and triage | within **7 days** |
+| Fix in a release candidate | within **30 days** for high-severity |
+| Public disclosure / advisory | **90 days** from initial report, or coordinated earlier if a patch is available |
+
+If we miss any of these targets, we will say so in
+`docs/triage-log.md` and the corresponding advisory thread. Misses are
+public; we don't hide them.
+
+## Supported versions
+
+Per [ADR-0024](docs/adr/0024-semver-and-api-stability.md), each crate
+has a stability tier. Security backports are provided as follows:
+
+| Tier | Versions receiving backports |
+|---|---|
+| **stable** (1.0+) | latest minor + previous minor |
+| **beta** | latest released version only |
+| **alpha** | latest released version only (best effort) |
+
+All current crates are alpha or beta. The full table lives in the ADR.
+
+## What counts as a vulnerability
+
+- Memory safety bugs (use-after-free, out-of-bounds, data race) in
+  first-party code.
+- Cryptographic misuse (e.g. accepting invalid certificates by default
+  — see ADR-0011).
+- Authentication, authorization, or input-validation bypasses.
+- Denial-of-service vectors that an attacker can trigger with bounded
+  input (e.g. unbounded allocation from network input —
+  ADR-0012/0015).
+- Supply-chain issues we can act on (e.g. a banned/vulnerable
+  transitive — ADR-0014 / `deny.toml`).
+
+## Not in scope (please don't file as security)
+
+- Performance regressions in benchmark code.
+- Bugs that require attacker-controlled local filesystem or unrestricted
+  shell access to exploit.
+- Issues in the vendored `hyprstream-main/` directory while ADR-0002
+  is in flight — those should be reported upstream.
+
+## Public disclosure
+
+Once a patch is available we publish a GitHub Security Advisory,
+request a CVE, and yank affected versions from crates.io. The advisory
+credits the reporter unless they request anonymity.


### PR DESCRIPTION
## Summary

Implements [ADR-0039](docs/adr/0039-governance.md). The repository
previously had **zero** governance artefacts: no CONTRIBUTING, no
Code of Conduct, no SECURITY policy, no CODEOWNERS, no PR or issue
templates, no Dependabot config. This PR lands all of them as the
project's contributor floor.

**Docs + config only. No source code touched.** 10 files, +764 / -0.

## What's added

| File | Purpose |
|---|---|
| `CONTRIBUTING.md` | DCO sign-off (no CLA), Conventional Commits, branch naming `<type>/<desc>-adr<NNNN>`, build/test cheat sheet that respects today's hyprstream-main block. |
| `CODE_OF_CONDUCT.md` | Contributor Covenant v2.1 verbatim; enforcement contact `conduct@ruv.net`. |
| `SECURITY.md` | GH Security Advisories preferred, `security@ruv.net` fallback. SLOs: **72h ack / 7d triage / 30d fix / 90d disclosure**. Misses logged publicly in `docs/triage-log.md`. |
| `GOVERNANCE.md` | One-screen. Maintainer = @ruv; ADRs for architecture; how to become a maintainer (~10 PRs over 6 months). |
| `.github/CODEOWNERS` | Routing rules for security-sensitive surface (`crates/quic-multistream`, `AIMDS`, `deny.toml`, `audit.yml`), hot-path crates (`nanosecond-scheduler`, `temporal-compare`), CI workflows, governance docs. All currently route to @ruv. |
| `.github/pull_request_template.md` | Checklist enforcing DCO, Conventional Commits, ADR linkage, bench numbers for perf-sensitive paths, `cargo deny` re-run for licence/dep changes, "no unrelated changes" gate. |
| `.github/ISSUE_TEMPLATE/bug_report.yml` | Structured: crate + version + rustc + OS + repro + expected + actual. |
| `.github/ISSUE_TEMPLATE/feature_request.yml` | Structured; steers large changes to ADR process via a Scope dropdown. |
| `.github/ISSUE_TEMPLATE/config.yml` | `blank_issues_enabled: false`. `contact_links` route security reports to GH Security Advisories (NEVER public issues), open-ended questions to Discussions, and architectural questions to the ADR index. |
| `.github/dependabot.yml` | Weekly Cargo / npm / Actions updates grouped by ecosystem (tokio-stack, rustls-stack, serde-stack, @types/*, patch updates). Ignores the vendored hyprstream chain (`duckdb`/`arrow*`/`hyprstream`) until ADR-0002 un-vendors. |

## Why DCO over CLA

Per ADR-0036, contributions are accepted under the dual `MIT OR
Apache-2.0` licence via per-commit `Signed-off-by:` trailers
([developercertificate.org](https://developercertificate.org/)). This
matches the Rust ecosystem norm and avoids the friction of a CLA bot.
A follow-up PR will enable [DCO Action](https://github.com/marketplace/actions/dco)
in CI to enforce the sign-off mechanically.

## Test plan

- [x] All 10 files added; no other files touched.
- [x] CODEOWNERS pattern order verified (broadest first, most-specific
      last, per GitHub semantics).
- [x] Issue templates use the `.yml` form (not `.md`) so GitHub
      renders structured form fields.
- [x] `config.yml` disables blank issues + adds the security routing
      link.
- [ ] After merge: enable GitHub Security Advisories in repo settings
      so the SECURITY.md link is live.
- [ ] After merge: add a DCO sign-off check via `dco.action` or
      equivalent.
- [ ] After merge: confirm Dependabot opens its first wave of PRs on
      the next Monday 07:30 UTC.

## Stacking

Independent of PRs #6, #7, #8, #9, #10, #11. Can merge in any order.

## What this doesn't do

- No CONTRIBUTING content for the Rust↔JS boundary (ADR-0027) or the
  pnpm workspace (ADR-0026); those land with their respective
  implementation PRs.
- No `triage-log.md` skeleton — created on first triage SLO miss
  rather than pre-emptively.
- No DCO CI gate — separate PR (small, targeted).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)