### PR TITLE
chore: npm-wasm features off-by-default; add full meta-feature (ADR-0025)

### DIFF
--- a/npm-wasm/Cargo.toml
+++ b/npm-wasm/Cargo.toml
@@ -10,12 +10,19 @@ repository = "https://github.com/midstream/midstream"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+# Feature flags follow ADR-0025: additive, off-by-default, prefixed.
+# A consumer of `@midstream/wasm` opts into the subsystems they need;
+# the historical "everything by default" behaviour is preserved as the
+# `full` meta-feature for one release while ecosystem users migrate.
 [features]
-default = ["temporal", "scheduler", "strange-loop", "quic"]
+default = []
 temporal = []
 scheduler = []
 strange-loop = []
 quic = []
+# Meta-feature: enables every published subsystem. Equivalent to the
+# pre-ADR-0025 `default` set. Deprecate one minor after migration.
+full = ["temporal", "scheduler", "strange-loop", "quic"]
 
 [dependencies]
 wasm-bindgen = "0.2.89"


### PR DESCRIPTION
## Summary

Implements [ADR-0025](docs/adr/0025-feature-flags-policy.md) for the
specific case of `npm-wasm/Cargo.toml`. Library crates default to the
smallest viable surface; risky / opinionated knobs are opt-in.

**1 file, +8 / −1.**

### Before

```toml
[features]
default = ["temporal", "scheduler", "strange-loop", "quic"]
temporal = []
scheduler = []
strange-loop = []
quic = []
```

Every downstream consumer of `@midstream/wasm` got the full kitchen-
sink build whether they wanted it or not, with no way to opt out
without `default-features = false`.

### After

```toml
[features]
default = []
temporal = []
scheduler = []
strange-loop = []
quic = []
full = ["temporal", "scheduler", "strange-loop", "quic"]
```

Migration is a one-liner:
- Want today's behaviour? `features = ["full"]`.
- Want only one subsystem? `features = ["temporal"]` (etc.).

`full` is deprecated-by-intent — it survives one minor release for
the migration window and goes away after.

## Caveat — the features are currently inert

The flags don't yet gate anything in the source (the arrays are
empty). The real `temporal = ["dep:midstreamer-temporal-compare"]`
form plus the `#[cfg(feature = "temporal")]` source gating lands in
the [ADR-0003 WASM consolidation](docs/adr/0003-wasm-consolidation.md)
PR. This PR corrects the **policy intent** so:

1. Manifest reviewers see the pattern.
2. The meta-feature shape is locked in for the source gating PR to
   plug into.
3. Anyone reading `cargo tree --features` on a downstream build sees
   only the features they explicitly opted into.

## Stacking

Independent of every other open PR. Tiny.

## Test plan

- [x] `npm-wasm` is excluded from the root workspace
      (`exclude = ["npm-wasm"]`), so this PR has no effect on
      `cargo check --workspace`.
- [x] Manifest parses (visual inspection).
- [ ] After [ADR-0003 WASM consolidation](docs/adr/0003-wasm-consolidation.md):
      the feature flags become real (gate `dep:midstreamer-*`),
      `full` enters its deprecation cycle, then disappears in the
      next minor.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)