### PR TITLE
chore: bump workspace to 0.1.1 + version specs (post-publish)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,18 +83,18 @@ dashmap = "6.1"
 lru = "0.12"
 
 # Phase 1: Temporal and Scheduling integrations (local workspace crates)
-midstreamer-temporal-compare = { path = "crates/temporal-compare" }
-midstreamer-scheduler = { path = "crates/nanosecond-scheduler" }
+midstreamer-temporal-compare = { version = "0.1.1", path = "crates/temporal-compare" }
+midstreamer-scheduler = { version = "0.1.1", path = "crates/nanosecond-scheduler" }
 
 # Phase 2: Dynamical systems and temporal logic (local workspace crates)
-midstreamer-attractor = { path = "crates/temporal-attractor-studio" }
-midstreamer-neural-solver = { path = "crates/temporal-neural-solver" }
+midstreamer-attractor = { version = "0.1.1", path = "crates/temporal-attractor-studio" }
+midstreamer-neural-solver = { version = "0.1.1", path = "crates/temporal-neural-solver" }
 
 # Phase 3: Meta-learning and self-reference (local workspace crates)
-midstreamer-strange-loop = { path = "crates/strange-loop" }
+midstreamer-strange-loop = { version = "0.1.1", path = "crates/strange-loop" }
 
 # QUIC multi-stream support (local workspace crate)
-midstreamer-quic = { path = "crates/quic-multistream" }
+midstreamer-quic = { version = "0.1.1", path = "crates/quic-multistream" }
 
 # Additional dependencies for advanced integrations
 nalgebra = "0.33" # For linear algebra in attractor analysis

--- a/crates/nanosecond-scheduler/Cargo.toml
+++ b/crates/nanosecond-scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midstreamer-scheduler"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.81"
 description = "Ultra-low-latency real-time task scheduler"

--- a/crates/strange-loop/Cargo.toml
+++ b/crates/strange-loop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midstreamer-strange-loop"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.81"
 description = "Self-referential systems and meta-learning"
@@ -13,10 +13,10 @@ categories = ["algorithms", "science"]
 workspace = true
 
 [dependencies]
-midstreamer-temporal-compare = { path = "../temporal-compare" }
-midstreamer-attractor = { path = "../temporal-attractor-studio" }
-midstreamer-neural-solver = { path = "../temporal-neural-solver" }
-midstreamer-scheduler = { path = "../nanosecond-scheduler" }
+midstreamer-temporal-compare = { version = "0.1.1", path = "../temporal-compare" }
+midstreamer-attractor = { version = "0.1.1", path = "../temporal-attractor-studio" }
+midstreamer-neural-solver = { version = "0.1.1", path = "../temporal-neural-solver" }
+midstreamer-scheduler = { version = "0.1.1", path = "../nanosecond-scheduler" }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "2.0"
 dashmap = "6.1"

--- a/crates/temporal-attractor-studio/Cargo.toml
+++ b/crates/temporal-attractor-studio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midstreamer-attractor"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.81"
 description = "Dynamical systems and strange attractors analysis"
@@ -13,7 +13,7 @@ categories = ["algorithms", "science", "visualization"]
 workspace = true
 
 [dependencies]
-midstreamer-temporal-compare = { path = "../temporal-compare" }
+midstreamer-temporal-compare = { version = "0.1.1", path = "../temporal-compare" }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "2.0"
 nalgebra = "0.33"

--- a/crates/temporal-compare/Cargo.toml
+++ b/crates/temporal-compare/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midstreamer-temporal-compare"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.81"
 description = "Temporal sequence comparison and pattern matching"

--- a/crates/temporal-neural-solver/Cargo.toml
+++ b/crates/temporal-neural-solver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midstreamer-neural-solver"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.81"
 description = "Temporal logic with neural reasoning"
@@ -13,7 +13,7 @@ categories = ["algorithms", "science"]
 workspace = true
 
 [dependencies]
-midstreamer-scheduler = { path = "../nanosecond-scheduler" }
+midstreamer-scheduler = { version = "0.1.1", path = "../nanosecond-scheduler" }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "2.0"
 ndarray = "0.16"


### PR DESCRIPTION
Bumps shipped to crates.io. midstream → 0.2.0 (semver-major per ADR-0005), 6 analysis crates → 0.1.1. Adds version specs to internal path deps so future publishes don't fail.