### PR TITLE
chore: replace config 0.13 with figment + dotenv with dotenvy (ADR-0019)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,12 +73,19 @@ serde_json = "1.0"
 async-trait = "0.1"
 futures = "0.3.31"
 tracing = "0.1"
-config = { version = "0.13", features = ["toml"] }
+# Config loader: `figment` replaces `config = "0.13"` per ADR-0019.
+# Closes the `yaml-rust` advisory in deny.toml — `config 0.13`
+# pulled in unmaintained `yaml-rust 0.4` transitively even when the
+# `yaml` feature was off. figment uses serde-native parsers
+# throughout and is on the cargo-deny `licenses` allowlist.
+figment = { version = "0.10", features = ["toml", "env"] }
 chrono = "0.4"
 reqwest = { version = "0.11", features = ["json", "stream"] }
 eventsource-stream = "0.2"
 tokio-stream = "0.1"
-dotenv = "0.15"
+# dotenv 0.15 is unmaintained (RUSTSEC-2021-0141). dotenvy is the
+# actively-maintained fork with an identical API (drop-in).
+dotenvy = "0.15"
 async-stream = "0.3"
 # Zero-copy buffers on the streaming hot path (ADR-0006).
 bytes = "1"

--- a/examples/openrouter.rs
+++ b/examples/openrouter.rs
@@ -5,7 +5,7 @@ use reqwest::Client;
 use serde_json::{json, Value};
 use std::time::Duration;
 use eventsource_stream::Eventsource;
-use dotenv::dotenv;
+use dotenvy::dotenv;
 
 struct OpenRouterClient {
     client: Client,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,31 @@
-use config::{Config, ConfigError, Environment, File};
+//! Configuration loading for midstream.
+//!
+//! Implementation per [ADR-0019](../../../docs/adr/0019-config-system.md).
+//! Layered sources (in order of precedence, last wins):
+//!
+//!   1. `config/default.toml`  — checked into the repo; safe defaults.
+//!   2. `config/local.toml`    — gitignored local override.
+//!   3. `MIDSTREAM_*` environment variables — single-`_` path
+//!      separator (so `MIDSTREAM_ENGINE_ENGINE` ⇒ `engine.engine`).
+//!
+//! The historical public surface (`HyprSettings::new`, `Default`
+//! impl, the three nested `*Settings` structs) is preserved exactly
+//! so this migration is a drop-in replacement for callers.
+
+use figment::{
+    providers::{Env, Format, Toml},
+    Figment,
+};
 use serde::Deserialize;
 use std::path::Path;
+
+/// Re-export of the underlying loader-error type so callers don't
+/// need a direct `figment` dependency just to spell out the error.
+/// The internal swap from `config 0.13` to `figment 0.10` per
+/// ADR-0019 changes this from `config::ConfigError` to
+/// `figment::Error` — a semver-major break by name, but the only
+/// thing callers do with it is `?` it.
+pub type ConfigError = figment::Error;
 
 #[derive(Debug, Deserialize)]
 pub struct HyprSettings {
@@ -24,18 +49,25 @@ pub struct CacheSettings {
 }
 
 impl HyprSettings {
+    /// Load configuration from the layered sources described in the
+    /// module-level docs.
+    ///
+    /// Returns `Err(ConfigError)` only on validation failures
+    /// (malformed TOML, type mismatch). Missing files are tolerated
+    /// — the only mandatory source is the env-var layer (which can
+    /// itself be empty).
     pub fn new() -> Result<Self, ConfigError> {
         let config_dir = Path::new("config");
-        
-        let builder = Config::builder()
-            // Start with default settings
-            .add_source(File::from(config_dir.join("default.toml")).required(false))
-            // Add local overrides
-            .add_source(File::from(config_dir.join("local.toml")).required(false))
-            // Add environment variables with prefix MIDSTREAM_
-            .add_source(Environment::with_prefix("MIDSTREAM").separator("_"));
 
-        builder.build()?.try_deserialize()
+        Figment::new()
+            // Defaults: missing file is fine.
+            .merge(Toml::file(config_dir.join("default.toml")))
+            // Local overrides: also missing-OK.
+            .merge(Toml::file(config_dir.join("local.toml")))
+            // Env vars with `MIDSTREAM_` prefix and `_` path separator.
+            // `MIDSTREAM_ENGINE_ENGINE=foo` ⇒ `engine.engine = "foo"`.
+            .merge(Env::prefixed("MIDSTREAM_").split("_"))
+            .extract()
     }
 }
 
@@ -66,7 +98,11 @@ mod tests {
 
     fn setup() {
         INIT.call_once(|| {
-            std::env::set_var("MIDSTREAM_ENGINE_ENGINE", "test_engine");
+            // SAFETY: this is a test helper that mutates process env;
+            // the `Once` guard prevents concurrent invocation.
+            unsafe {
+                std::env::set_var("MIDSTREAM_ENGINE_ENGINE", "test_engine");
+            }
         });
     }
 


### PR DESCRIPTION
Closes RUSTSEC-2024-0320 (yaml-rust) and RUSTSEC-2021-0141 (dotenv). `cargo tree -i yaml-rust` now returns no path. Public API of `HyprSettings` preserved exactly; `ConfigError` aliased to `figment::Error`. Env-var path separator stays single-`_` for now; ADR-0019's `__` switch deferred to a follow-up to keep this PR scoped.