### PR TITLE
chore(security): retire 3 cleared deny.toml advisory ignores

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -45,17 +45,18 @@ ignore = [
     { id = "RUSTSEC-2026-0002", reason = "lru<0.18; pending workspace bump per ADR-0014" },
     # ------------------------------------------------------------------
     # In-flight: unmaintained transitives.
-    #   * yaml-rust 0.4.5 (via config 0.13)         — ADR-0019 (figment)
-    #   * dotenv 0.15.0    (direct, root Cargo.toml) — ADR-0019 (dotenvy)
-    #   * bincode 1.3.3    (via duckdb)              — ADR-0002 (un-vendor hyprstream)
-    #   * paste 1.0.15     (transitive proc-macro)   — ADR-0002 chain
-    #   * rustls-pemfile 1.0.4 (via tonic)           — ADR-0002 chain
+    #
+    # Retired (verified via `cargo tree -i <crate>` returning no path):
+    #   * RUSTSEC-2024-0320 yaml-rust  — cleared by ADR-0019 figment migration
+    #   * RUSTSEC-2021-0141 dotenv     — cleared by ADR-0019 dotenvy migration
+    #   * RUSTSEC-2025-0141 bincode    — cleared by ADR-0002 hyprstream un-vendor
+    #
+    # Still in tree (follow-up ADRs):
+    #   * paste 1.0.15        via nalgebra -> simba         — needs nalgebra audit
+    #   * rustls-pemfile 1.0.4 via reqwest 0.11             — needs reqwest 0.11 -> 0.12 bump
     # Expiries: 2026-08-13 (quarterly review).
-    { id = "RUSTSEC-2024-0320", reason = "yaml-rust via config 0.13; ADR-0019 (figment)" },
-    { id = "RUSTSEC-2021-0141", reason = "dotenv direct; ADR-0019 (switch to dotenvy)" },
-    { id = "RUSTSEC-2025-0141", reason = "bincode via duckdb; cleared by ADR-0002" },
-    { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile via tonic 0.12; cleared by ADR-0002 chain" },
-    { id = "RUSTSEC-2024-0436", reason = "paste transitive; cleared by ADR-0002 chain" },
+    { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile via reqwest 0.11; bump reqwest" },
+    { id = "RUSTSEC-2024-0436", reason = "paste via nalgebra->simba; nalgebra audit" },
 ]
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
After PR #13 + PR #52, yaml-rust / dotenv / bincode are all gone from the dep graph. `cargo tree -i` verifies. Ignore list shrinks 5 → 2. Remaining: rustls-pemfile (via reqwest 0.11), paste (via nalgebra).