### PR TITLE
chore(release): bump midstreamer-scheduler 0.1.1 → 0.1.2 (cmp bugfix; published + 0.1.1 yanked)

### DIFF
--- a/crates/nanosecond-scheduler/Cargo.toml
+++ b/crates/nanosecond-scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midstreamer-scheduler"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 rust-version = "1.81"
 description = "Ultra-low-latency real-time task scheduler"


### PR DESCRIPTION
Ships PR #60's cmp bugfix to crates.io as midstreamer-scheduler 0.1.2. `cargo publish` succeeded; `cargo yank --version 0.1.1` executed so downstream auto-upgrades. Dependent crates (strange-loop, neural-solver) have `version = "0.1.1"` which is `^0.1.1` and resolves to 0.1.2 automatically.