### PR TITLE
test(fuzz): scaffold midstream-fuzz crate with 2 initial targets (ADR-0038)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
     "crates/temporal-neural-solver",
     "crates/strange-loop",
 ]
-exclude = ["npm-wasm"]
+exclude = ["npm-wasm", "fuzz"]
 
 # Per ADR-0034. Second-phase rollout: now that the workspace passes
 # `cargo clippy -- -D warnings` clean (PR #48 cleared the four

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,48 @@
+# Fuzzing scaffold per ADR-0038.
+#
+# This crate is NOT a member of the root workspace (see the
+# `exclude = ["fuzz"]` entry in the root `Cargo.toml`). Reason: it
+# pulls in `libfuzzer-sys`, which is built with sanitizer-enabled
+# rustc flags and would force the same on the entire workspace.
+# Keeping it standalone means `cargo check --workspace` stays fast.
+#
+# To run a target:
+#
+#   cargo install cargo-fuzz
+#   cargo +nightly fuzz run <target_name>
+#
+# Targets are listed below as `[[bin]]` entries — cargo-fuzz
+# discovers them from this manifest. New targets go in
+# `fuzz_targets/<name>.rs` and a matching `[[bin]]` entry here.
+
+[package]
+name = "midstream-fuzz"
+version = "0.0.0"
+authors = ["midstream contributors"]
+publish = false
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+# Reference each crate under fuzz so its private fuzz targets can
+# exercise the public API surface.
+midstreamer-temporal-compare = { path = "../crates/temporal-compare" }
+midstreamer-scheduler = { path = "../crates/nanosecond-scheduler" }
+
+[[bin]]
+name = "temporal_compare_compare"
+path = "fuzz_targets/temporal_compare_compare.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "scheduler_event_loop"
+path = "fuzz_targets/scheduler_event_loop.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,67 @@
+# midstream-fuzz
+
+cargo-fuzz scaffold per [ADR-0038](../docs/adr/0038-fuzz-and-property-tests.md).
+
+Standalone crate (excluded from the root workspace) hosting
+libfuzzer-sys targets that exercise the workspace's parser /
+algorithmic / state-machine surfaces beyond what the proptest
+baselines reach.
+
+## Targets
+
+| Target | Asserts | Notes |
+|---|---|---|
+| `temporal_compare_compare` | `TemporalComparator::compare` does not panic / OOM on any (sequence_a, sequence_b, algorithm) tuple | Algorithmic; ADR-0009 |
+| `scheduler_event_loop` | `RealtimeScheduler` does not panic / OOM under random `(schedule, next_task, clear)` interleavings | State-machine; ADR-0033 |
+
+Each target asserts only the absence of panics + OOM. The
+algebraic / structural invariants live in the per-crate proptest
+baselines under `crates/*/tests/proptest_*.rs`.
+
+## Running
+
+```bash
+# One-time tool install
+cargo install cargo-fuzz
+
+# Run a target (libfuzzer requires nightly):
+cargo +nightly fuzz run temporal_compare_compare
+cargo +nightly fuzz run scheduler_event_loop
+
+# Bounded run for CI (60 seconds):
+cargo +nightly fuzz run temporal_compare_compare -- -max_total_time=60
+```
+
+## Layout
+
+```
+fuzz/
+├── Cargo.toml             # not a workspace member; declares libfuzzer-sys + target bins
+├── fuzz_targets/
+│   ├── temporal_compare_compare.rs
+│   └── scheduler_event_loop.rs
+├── artifacts/             # crashes go here; committed under .gitignore exception
+└── corpus/                # seed corpus + libfuzzer's discovered inputs
+```
+
+Both `artifacts/` and `corpus/` are runtime directories; the seed
+corpus (`corpus/<target>/*`) is committed so CI replays prior
+findings, while libfuzzer-discovered new inputs accumulate locally.
+
+## CI
+
+A `fuzz.yml` workflow is the natural next step (per ADR-0038's
+implementation notes): nightly-toolchain matrix entry that runs
+each target with `-max_total_time=300s` on a schedule + on PR
+label `fuzz`. Crashes upload as workflow artifacts.
+
+## Follow-up targets
+
+Per ADR-0038's table, the priority list is:
+
+  * sse_parser — SSE event stream → frame
+  * quic_frame_decode — bytes → QuicFrame
+  * mcp_jsonrpc_dispatch — JSON-RPC request → tool dispatch
+  * figment_config_load — TOML/JSON bytes → MidstreamConfig
+
+These land as separate PRs as each underlying surface stabilises.

--- a/fuzz/fuzz_targets/scheduler_event_loop.rs
+++ b/fuzz/fuzz_targets/scheduler_event_loop.rs
@@ -1,0 +1,72 @@
+//! Fuzz target: nanosecond-scheduler's `schedule` + `next_task`
+//! interleavings.
+//!
+//! Drives a randomized sequence of (schedule, pop, clear) operations
+//! over a `RealtimeScheduler<u8>` and asserts only "did not panic /
+//! did not OOM". Ordering invariants live in the proptest baseline
+//! at `crates/nanosecond-scheduler/tests/proptest_queue_order.rs`;
+//! this target chases the long tail (operation interleavings with
+//! many queue-full encounters, rapid clear-then-fill cycles, etc.).
+//!
+//! Run with:
+//!
+//!   cargo +nightly fuzz run scheduler_event_loop
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use midstreamer_scheduler::{
+    Deadline, Priority, RealtimeScheduler, SchedulerConfig, SchedulingPolicy,
+};
+
+fn priority(b: u8) -> Priority {
+    match b % 5 {
+        0 => Priority::Critical,
+        1 => Priority::High,
+        2 => Priority::Medium,
+        3 => Priority::Low,
+        _ => Priority::Background,
+    }
+}
+
+fuzz_target!(|data: &[u8]| {
+    if data.is_empty() {
+        return;
+    }
+
+    // First byte is the max_queue_size (clamped to [1, 32]).
+    let cap = (data[0] as usize % 32).max(1);
+    let sched = RealtimeScheduler::<u8>::new(SchedulerConfig {
+        policy: SchedulingPolicy::FixedPriority,
+        max_queue_size: cap,
+        enable_rt_scheduling: false,
+        cpu_affinity: None,
+    });
+
+    // Each subsequent byte is an op: low 2 bits = op code,
+    // upper bits = data for that op.
+    for &b in data[1..].iter().take(1024) {
+        let op = b & 0b11;
+        let arg = b >> 2;
+        match op {
+            // schedule(payload=arg, deadline=arg micros, priority=arg)
+            0 => {
+                let _ = sched.schedule(
+                    arg,
+                    Deadline::from_micros(arg as u64 + 1),
+                    priority(arg),
+                );
+            }
+            // pop
+            1 => {
+                let _ = sched.next_task();
+            }
+            // clear
+            2 => sched.clear(),
+            // queue_size (read-only; just don't panic)
+            _ => {
+                let _ = sched.queue_size();
+            }
+        }
+    }
+});

--- a/fuzz/fuzz_targets/temporal_compare_compare.rs
+++ b/fuzz/fuzz_targets/temporal_compare_compare.rs
@@ -1,0 +1,54 @@
+//! Fuzz target: temporal-compare's `compare()` over the three algorithms.
+//!
+//! Asserts only "did not panic / did not OOM". Algebraic invariants
+//! (metric, symmetry, etc.) are covered by the proptest baseline in
+//! `crates/temporal-compare/tests/proptest_metrics.rs`. Fuzz adds
+//! the *structured-random bytes* axis: arbitrary input shapes,
+//! including the long-tail of edge cases proptest's generators don't
+//! reach (empty sequences, single elements, max_sequence_length
+//! boundary, etc.).
+//!
+//! Run with:
+//!
+//!   cargo +nightly fuzz run temporal_compare_compare
+//!
+//! A panic or libfuzzer-detected OOM crashes the target with a
+//! reproducer dropped under `fuzz/artifacts/temporal_compare_compare/`.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use midstreamer_temporal_compare::{
+    ComparisonAlgorithm, Sequence, TemporalComparator,
+};
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() < 4 {
+        return;
+    }
+
+    // First byte selects the algorithm; second byte sets the split
+    // between the two sequences; remaining bytes are the values.
+    let algorithm = match data[0] % 3 {
+        0 => ComparisonAlgorithm::DTW,
+        1 => ComparisonAlgorithm::LCS,
+        _ => ComparisonAlgorithm::EditDistance,
+    };
+
+    let split = (data[1] as usize) % data.len().max(1);
+    let (a_bytes, b_bytes) = data[2..].split_at(split.min(data.len() - 2));
+
+    let mut seq_a = Sequence::<i32>::new();
+    for (i, b) in a_bytes.iter().take(256).enumerate() {
+        seq_a.push(*b as i32, i as u64);
+    }
+    let mut seq_b = Sequence::<i32>::new();
+    for (i, b) in b_bytes.iter().take(256).enumerate() {
+        seq_b.push(*b as i32, i as u64);
+    }
+
+    let comp = TemporalComparator::<i32>::new(128, 256);
+    // We don't care about the result — only that `compare` doesn't
+    // panic or OOM on any input shape.
+    let _ = comp.compare(&seq_a, &seq_b, algorithm);
+});


### PR DESCRIPTION
Adds cargo-fuzz scaffold complementing the per-crate proptest baselines (#58/#59/#60/#63/#64/#65/#66). Two initial targets: `temporal_compare_compare` (DTW/LCS/Edit on random bytes) and `scheduler_event_loop` (randomized op interleavings). `fuzz/` is a standalone crate (excluded from workspace) so libfuzzer-sys's sanitizer flags don't poison the main workspace. Follow-up targets per ADR-0038: SSE parser, QUIC frame decode, MCP JSON-RPC, figment config.