### PR TITLE
fix(release): grant contents: write so create-release can POST to GH

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,17 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
+# Required for softprops/action-gh-release to POST to the GitHub
+# Releases API. Without `contents: write` the action 403s with
+# "Resource not accessible by integration" and the entire downstream
+# pipeline (build-release, publish-crates, update-docs) is skipped.
+# Repro: v0.2.1 tag push 2026-05-13 — release was created but
+# nothing published. Adding workflow-level permissions here so every
+# job inherits the minimum it needs; jobs that don't touch the API
+# (build-release, publish-crates) cost nothing extra.
+permissions:
+  contents: write
+
 jobs:
   # Create GitHub release
   create-release:


### PR DESCRIPTION
## Summary

v0.2.1 tag push fired release.yml; the \`Create Release\` job 403'd with \"Resource not accessible by integration\" because the workflow's \`GITHUB_TOKEN\` defaulted to read-only. Cascade: build-release, publish-crates, and update-docs all skipped — **no crates were published to crates.io**.

Add a workflow-level \`permissions: contents: write\` block so softprops/action-gh-release can create the release. publish-crates uses its own \`CARGO_REGISTRY_TOKEN\` secret so it doesn't need any extra permission.

## After merge

Delete the dead v0.2.1 tag + re-push to re-fire the workflow:

\`\`\`
git tag -d v0.2.1
git push --delete origin v0.2.1
git tag v0.2.1 <main-sha>
git push origin v0.2.1
\`\`\`

## Test plan

- [x] Failure repro confirmed in [run #25836415375](https://github.com/ruvnet/midstream/actions/runs/25836415375)
- [ ] After merge + re-tag: release.yml completes all 5 jobs
- [ ] 6 \`midstreamer-*\` libs visible on crates.io at 0.2.1

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)