### PR TITLE
chore: cargo fmt --all baseline

### DIFF
--- a/benches/attractor_bench.rs
+++ b/benches/attractor_bench.rs
@@ -13,13 +13,11 @@
 //! - Lyapunov: <500ms
 //! - Detection: <100ms
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId, Throughput};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use midstreamer_attractor::{
-    AttractorStudio, PhaseSpace, Trajectory, AttractorType,
-    lyapunov::calculate_lyapunov_exponent,
-    embedding::reconstruct_phase_space,
-    detection::detect_attractor_type,
-    dimension::estimate_correlation_dimension,
+    detection::detect_attractor_type, dimension::estimate_correlation_dimension,
+    embedding::reconstruct_phase_space, lyapunov::calculate_lyapunov_exponent, AttractorStudio,
+    AttractorType, PhaseSpace, Trajectory,
 };
 
 // ============================================================================
@@ -100,12 +98,12 @@ fn generate_time_series(n: usize, pattern: &str) -> Vec<f64> {
             let lorenz = generate_lorenz_attractor(n);
             lorenz.iter().map(|(x, _, _)| *x).collect()
         }
-        "random" => (0..n).map(|i| {
-            ((i as f64 * 7919.0).sin() * 10000.0) % 100.0
-        }).collect(),
-        "periodic" => (0..n).map(|i| {
-            (i as f64 * 0.1).sin() + 0.5 * (i as f64 * 0.3).sin()
-        }).collect(),
+        "random" => (0..n)
+            .map(|i| ((i as f64 * 7919.0).sin() * 10000.0) % 100.0)
+            .collect(),
+        "periodic" => (0..n)
+            .map(|i| (i as f64 * 0.1).sin() + 0.5 * (i as f64 * 0.3).sin())
+            .collect(),
         _ => vec![0.0; n],
     }
 }
@@ -121,52 +119,40 @@ fn bench_phase_space_embedding(c: &mut Criterion) {
         group.throughput(Throughput::Elements(*size as u64));
 
         // Dimension 2
-        group.bench_with_input(
-            BenchmarkId::new("dim2", size),
-            size,
-            |b, &n| {
-                let data = generate_time_series(n, "chaotic");
-                b.iter(|| {
-                    black_box(reconstruct_phase_space(
-                        black_box(&data),
-                        black_box(2),
-                        black_box(1)
-                    ))
-                });
-            }
-        );
+        group.bench_with_input(BenchmarkId::new("dim2", size), size, |b, &n| {
+            let data = generate_time_series(n, "chaotic");
+            b.iter(|| {
+                black_box(reconstruct_phase_space(
+                    black_box(&data),
+                    black_box(2),
+                    black_box(1),
+                ))
+            });
+        });
 
         // Dimension 3
-        group.bench_with_input(
-            BenchmarkId::new("dim3", size),
-            size,
-            |b, &n| {
-                let data = generate_time_series(n, "chaotic");
-                b.iter(|| {
-                    black_box(reconstruct_phase_space(
-                        black_box(&data),
-                        black_box(3),
-                        black_box(1)
-                    ))
-                });
-            }
-        );
+        group.bench_with_input(BenchmarkId::new("dim3", size), size, |b, &n| {
+            let data = generate_time_series(n, "chaotic");
+            b.iter(|| {
+                black_box(reconstruct_phase_space(
+                    black_box(&data),
+                    black_box(3),
+                    black_box(1),
+                ))
+            });
+        });
 
         // Dimension 5
-        group.bench_with_input(
-            BenchmarkId::new("dim5", size),
-            size,
-            |b, &n| {
-                let data = generate_time_series(n, "chaotic");
-                b.iter(|| {
-                    black_box(reconstruct_phase_space(
-                        black_box(&data),
-                        black_box(5),
-                        black_box(1)
-                    ))
-                });
-            }
-        );
+        group.bench_with_input(BenchmarkId::new("dim5", size), size, |b, &n| {
+            let data = generate_time_series(n, "chaotic");
+            b.iter(|| {
+                black_box(reconstruct_phase_space(
+                    black_box(&data),
+                    black_box(5),
+                    black_box(1),
+                ))
+            });
+        });
     }
 
     group.finish();
@@ -178,19 +164,15 @@ fn bench_embedding_delays(c: &mut Criterion) {
     let data = generate_time_series(1000, "chaotic");
 
     for delay in [1, 5, 10, 20, 50].iter() {
-        group.bench_with_input(
-            BenchmarkId::new("delay", delay),
-            delay,
-            |b, &d| {
-                b.iter(|| {
-                    black_box(reconstruct_phase_space(
-                        black_box(&data),
-                        black_box(3),
-                        black_box(d)
-                    ))
-                });
-            }
-        );
+        group.bench_with_input(BenchmarkId::new("delay", delay), delay, |b, &d| {
+            b.iter(|| {
+                black_box(reconstruct_phase_space(
+                    black_box(&data),
+                    black_box(3),
+                    black_box(d),
+                ))
+            });
+        });
     }
 
     group.finish();
@@ -212,7 +194,7 @@ fn bench_lyapunov_calculation(c: &mut Criterion) {
             black_box(calculate_lyapunov_exponent(
                 black_box(&trajectory),
                 black_box(3),
-                black_box(10)
+                black_box(10),
             ))
         });
     });
@@ -225,7 +207,7 @@ fn bench_lyapunov_calculation(c: &mut Criterion) {
             black_box(calculate_lyapunov_exponent(
                 black_box(&trajectory),
                 black_box(3),
-                black_box(10)
+                black_box(10),
             ))
         });
     });
@@ -237,27 +219,23 @@ fn bench_lyapunov_calculation(c: &mut Criterion) {
             black_box(calculate_lyapunov_exponent(
                 black_box(&trajectory),
                 black_box(3),
-                black_box(10)
+                black_box(10),
             ))
         });
     });
 
     // Varying data sizes
     for size in [500, 1000, 2000, 5000].iter() {
-        group.bench_with_input(
-            BenchmarkId::new("size", size),
-            size,
-            |b, &n| {
-                let trajectory = generate_time_series(n, "chaotic");
-                b.iter(|| {
-                    black_box(calculate_lyapunov_exponent(
-                        black_box(&trajectory),
-                        black_box(3),
-                        black_box(10)
-                    ))
-                });
-            }
-        );
+        group.bench_with_input(BenchmarkId::new("size", size), size, |b, &n| {
+            let trajectory = generate_time_series(n, "chaotic");
+            b.iter(|| {
+                black_box(calculate_lyapunov_exponent(
+                    black_box(&trajectory),
+                    black_box(3),
+                    black_box(10),
+                ))
+            });
+        });
     }
 
     group.finish();
@@ -274,31 +252,21 @@ fn bench_attractor_detection(c: &mut Criterion) {
     group.bench_function("lorenz_detection", |b| {
         let points = generate_lorenz_attractor(1000);
 
-        b.iter(|| {
-            black_box(detect_attractor_type(black_box(&points)))
-        });
+        b.iter(|| black_box(detect_attractor_type(black_box(&points))));
     });
 
     group.bench_function("rossler_detection", |b| {
         let points = generate_rossler_attractor(1000);
 
-        b.iter(|| {
-            black_box(detect_attractor_type(black_box(&points)))
-        });
+        b.iter(|| black_box(detect_attractor_type(black_box(&points))));
     });
 
     // Different data sizes
     for size in [100, 500, 1000, 2000].iter() {
-        group.bench_with_input(
-            BenchmarkId::new("size", size),
-            size,
-            |b, &n| {
-                let points = generate_lorenz_attractor(n);
-                b.iter(|| {
-                    black_box(detect_attractor_type(black_box(&points)))
-                });
-            }
-        );
+        group.bench_with_input(BenchmarkId::new("size", size), size, |b, &n| {
+            let points = generate_lorenz_attractor(n);
+            b.iter(|| black_box(detect_attractor_type(black_box(&points))));
+        });
     }
 
     group.finish();
@@ -326,9 +294,7 @@ fn bench_trajectory_analysis(c: &mut Criterion) {
         let points = generate_lorenz_attractor(1000);
         let trajectory = Trajectory::from_points(points);
 
-        b.iter(|| {
-            black_box(trajectory.calculate_distances())
-        });
+        b.iter(|| black_box(trajectory.calculate_distances()));
     });
 
     // Nearest neighbors
@@ -336,9 +302,7 @@ fn bench_trajectory_analysis(c: &mut Criterion) {
         let points = generate_lorenz_attractor(1000);
         let trajectory = Trajectory::from_points(points);
 
-        b.iter(|| {
-            black_box(trajectory.find_nearest_neighbors(black_box(10)))
-        });
+        b.iter(|| black_box(trajectory.find_nearest_neighbors(black_box(10))));
     });
 
     group.finish();
@@ -358,41 +322,34 @@ fn bench_dimension_estimation(c: &mut Criterion) {
         b.iter(|| {
             black_box(estimate_correlation_dimension(
                 black_box(&points),
-                black_box(20)
+                black_box(20),
             ))
         });
     });
 
     group.bench_function("correlation_dim_henon", |b| {
         let points = generate_henon_map(1000);
-        let points_3d: Vec<(f64, f64, f64)> = points
-            .iter()
-            .map(|(x, y)| (*x, *y, 0.0))
-            .collect();
+        let points_3d: Vec<(f64, f64, f64)> = points.iter().map(|(x, y)| (*x, *y, 0.0)).collect();
 
         b.iter(|| {
             black_box(estimate_correlation_dimension(
                 black_box(&points_3d),
-                black_box(20)
+                black_box(20),
             ))
         });
     });
 
     // Varying sample sizes
     for size in [500, 1000, 2000].iter() {
-        group.bench_with_input(
-            BenchmarkId::new("size", size),
-            size,
-            |b, &n| {
-                let points = generate_lorenz_attractor(n);
-                b.iter(|| {
-                    black_box(estimate_correlation_dimension(
-                        black_box(&points),
-                        black_box(20)
-                    ))
-                });
-            }
-        );
+        group.bench_with_input(BenchmarkId::new("size", size), size, |b, &n| {
+            let points = generate_lorenz_attractor(n);
+            b.iter(|| {
+                black_box(estimate_correlation_dimension(
+                    black_box(&points),
+                    black_box(20),
+                ))
+            });
+        });
     }
 
     group.finish();
@@ -454,10 +411,8 @@ fn bench_complete_analysis(c: &mut Criterion) {
             let phase_space = reconstruct_phase_space(&data, 3, 10);
 
             // Convert to 3D points for analysis
-            let points: Vec<(f64, f64, f64)> = phase_space
-                .iter()
-                .map(|p| (p[0], p[1], p[2]))
-                .collect();
+            let points: Vec<(f64, f64, f64)> =
+                phase_space.iter().map(|p| (p[0], p[1], p[2])).collect();
 
             // Attractor detection
             let attractor_type = detect_attractor_type(&points);

--- a/benches/lean_agentic_bench.rs
+++ b/benches/lean_agentic_bench.rs
@@ -2,16 +2,13 @@
 //!
 //! Run with: cargo bench
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId, Throughput};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use midstream::{
-    LeanAgenticSystem, LeanAgenticConfig, AgentContext,
-    FormalReasoner, AgenticLoop, KnowledgeGraph, StreamLearner,
-    Action, Entity, EntityType,
-    TemporalComparator, Sequence, ComparisonAlgorithm,
-    RealtimeScheduler, SchedulingPolicy, Priority,
-    AttractorAnalyzer, BehaviorAttractorAnalyzer, Trajectory,
-    TemporalNeuralSolver, TemporalFormula, TemporalTrace, TemporalState,
-    MetaLearner, MetaLevel,
+    Action, AgentContext, AgenticLoop, AttractorAnalyzer, BehaviorAttractorAnalyzer,
+    ComparisonAlgorithm, Entity, EntityType, FormalReasoner, KnowledgeGraph, LeanAgenticConfig,
+    LeanAgenticSystem, MetaLearner, MetaLevel, Priority, RealtimeScheduler, SchedulingPolicy,
+    Sequence, StreamLearner, TemporalComparator, TemporalFormula, TemporalNeuralSolver,
+    TemporalState, TemporalTrace, Trajectory,
 };
 use std::collections::HashMap;
 use tokio::runtime::Runtime;
@@ -47,10 +44,9 @@ fn benchmark_formal_reasoning(c: &mut Criterion) {
             rt.block_on(async {
                 let mut reasoner = FormalReasoner::new();
                 black_box(
-                    reasoner.prove_theorem(
-                        "Q".to_string(),
-                        vec!["P".to_string(), "P -> Q".to_string()],
-                    ).await
+                    reasoner
+                        .prove_theorem("Q".to_string(), vec!["P".to_string(), "P -> Q".to_string()])
+                        .await,
                 )
             })
         });
@@ -249,7 +245,10 @@ fn benchmark_end_to_end(c: &mut Criterion) {
                     for i in 0..size {
                         let chunk = format!("Message {} with some content", i);
                         black_box(
-                            system.process_stream_chunk(&chunk, context.clone()).await.unwrap()
+                            system
+                                .process_stream_chunk(&chunk, context.clone())
+                                .await
+                                .unwrap(),
                         );
                         context.add_message(chunk);
                     }
@@ -308,36 +307,24 @@ fn benchmark_temporal_comparison(c: &mut Criterion) {
 
     // Benchmark DTW with different sequence sizes
     for size in [10, 50, 100, 200].iter() {
-        group.bench_with_input(
-            BenchmarkId::new("dtw", size),
-            size,
-            |b, &size| {
-                let mut comparator = TemporalComparator::<i32>::new();
-                let seq1: Vec<i32> = (0..size).collect();
-                let seq2: Vec<i32> = (0..size).map(|x| x + (x % 3)).collect();
+        group.bench_with_input(BenchmarkId::new("dtw", size), size, |b, &size| {
+            let mut comparator = TemporalComparator::<i32>::new();
+            let seq1: Vec<i32> = (0..size).collect();
+            let seq2: Vec<i32> = (0..size).map(|x| x + (x % 3)).collect();
 
-                b.iter(|| {
-                    black_box(comparator.compare(&seq1, &seq2, ComparisonAlgorithm::DTW))
-                });
-            },
-        );
+            b.iter(|| black_box(comparator.compare(&seq1, &seq2, ComparisonAlgorithm::DTW)));
+        });
     }
 
     // Benchmark LCS
     for size in [10, 50, 100, 200].iter() {
-        group.bench_with_input(
-            BenchmarkId::new("lcs", size),
-            size,
-            |b, &size| {
-                let mut comparator = TemporalComparator::<i32>::new();
-                let seq1: Vec<i32> = (0..size).collect();
-                let seq2: Vec<i32> = (0..size).map(|x| x + (x % 2)).collect();
+        group.bench_with_input(BenchmarkId::new("lcs", size), size, |b, &size| {
+            let mut comparator = TemporalComparator::<i32>::new();
+            let seq1: Vec<i32> = (0..size).collect();
+            let seq2: Vec<i32> = (0..size).map(|x| x + (x % 2)).collect();
 
-                b.iter(|| {
-                    black_box(comparator.compare(&seq1, &seq2, ComparisonAlgorithm::LCS))
-                });
-            },
-        );
+            b.iter(|| black_box(comparator.compare(&seq1, &seq2, ComparisonAlgorithm::LCS)));
+        });
     }
 
     // Benchmark edit distance
@@ -346,9 +333,7 @@ fn benchmark_temporal_comparison(c: &mut Criterion) {
         let seq1: Vec<char> = "kitten".chars().collect();
         let seq2: Vec<char> = "sitting".chars().collect();
 
-        b.iter(|| {
-            black_box(comparator.compare(&seq1, &seq2, ComparisonAlgorithm::EditDistance))
-        });
+        b.iter(|| black_box(comparator.compare(&seq1, &seq2, ComparisonAlgorithm::EditDistance)));
     });
 
     // Benchmark pattern detection
@@ -357,9 +342,7 @@ fn benchmark_temporal_comparison(c: &mut Criterion) {
         let sequence: Vec<i32> = (0..1000).map(|x| x % 10).collect();
         let pattern = vec![1, 2, 3];
 
-        b.iter(|| {
-            black_box(comparator.detect_pattern(&sequence, &pattern))
-        });
+        b.iter(|| black_box(comparator.detect_pattern(&sequence, &pattern)));
     });
 
     // Benchmark find similar with cache
@@ -377,9 +360,7 @@ fn benchmark_temporal_comparison(c: &mut Criterion) {
 
         let query: Vec<i32> = (0..50).collect();
 
-        b.iter(|| {
-            black_box(comparator.find_similar(&query, 0.7, ComparisonAlgorithm::LCS))
-        });
+        b.iter(|| black_box(comparator.find_similar(&query, 0.7, ComparisonAlgorithm::LCS)));
     });
 
     group.finish();
@@ -405,12 +386,14 @@ fn benchmark_scheduler(c: &mut Criterion) {
                 };
 
                 black_box(
-                    scheduler.schedule(
-                        action,
-                        Priority::Medium,
-                        std::time::Duration::from_secs(1),
-                        std::time::Duration::from_millis(10),
-                    ).await
+                    scheduler
+                        .schedule(
+                            action,
+                            Priority::Medium,
+                            std::time::Duration::from_secs(1),
+                            std::time::Duration::from_millis(10),
+                        )
+                        .await,
                 )
             })
         });
@@ -433,12 +416,14 @@ fn benchmark_scheduler(c: &mut Criterion) {
                         expected_reward: 0.8,
                     };
 
-                    scheduler.schedule(
-                        action,
-                        Priority::Medium,
-                        std::time::Duration::from_millis(100 + i * 10),
-                        std::time::Duration::from_millis(10),
-                    ).await;
+                    scheduler
+                        .schedule(
+                            action,
+                            Priority::Medium,
+                            std::time::Duration::from_millis(100 + i * 10),
+                            std::time::Duration::from_millis(10),
+                        )
+                        .await;
                 }
 
                 black_box(scheduler.next_task().await)
@@ -453,7 +438,12 @@ fn benchmark_scheduler(c: &mut Criterion) {
                 let scheduler = RealtimeScheduler::new(SchedulingPolicy::FixedPriority);
 
                 // Schedule tasks with different priorities
-                for priority in &[Priority::Low, Priority::Medium, Priority::High, Priority::Critical] {
+                for priority in &[
+                    Priority::Low,
+                    Priority::Medium,
+                    Priority::High,
+                    Priority::Critical,
+                ] {
                     let action = Action {
                         action_type: format!("task_{:?}", priority),
                         description: format!("Task {:?}", priority),
@@ -463,12 +453,14 @@ fn benchmark_scheduler(c: &mut Criterion) {
                         expected_reward: 0.8,
                     };
 
-                    scheduler.schedule(
-                        action,
-                        *priority,
-                        std::time::Duration::from_secs(1),
-                        std::time::Duration::from_millis(10),
-                    ).await;
+                    scheduler
+                        .schedule(
+                            action,
+                            *priority,
+                            std::time::Duration::from_secs(1),
+                            std::time::Duration::from_millis(10),
+                        )
+                        .await;
                 }
 
                 black_box(scheduler.next_task().await)
@@ -484,7 +476,8 @@ fn benchmark_scheduler(c: &mut Criterion) {
             |b, &num_tasks| {
                 b.iter(|| {
                     rt.block_on(async {
-                        let scheduler = RealtimeScheduler::new(SchedulingPolicy::EarliestDeadlineFirst);
+                        let scheduler =
+                            RealtimeScheduler::new(SchedulingPolicy::EarliestDeadlineFirst);
 
                         for i in 0..num_tasks {
                             let action = Action {
@@ -496,12 +489,14 @@ fn benchmark_scheduler(c: &mut Criterion) {
                                 expected_reward: 0.8,
                             };
 
-                            scheduler.schedule(
-                                action,
-                                Priority::Medium,
-                                std::time::Duration::from_millis(100),
-                                std::time::Duration::from_millis(10),
-                            ).await;
+                            scheduler
+                                .schedule(
+                                    action,
+                                    Priority::Medium,
+                                    std::time::Duration::from_millis(100),
+                                    std::time::Duration::from_millis(10),
+                                )
+                                .await;
                         }
 
                         // Retrieve all tasks
@@ -524,25 +519,19 @@ fn benchmark_attractor_analysis(c: &mut Criterion) {
 
     // Benchmark attractor detection with different data sizes
     for size in [100, 500, 1000].iter() {
-        group.bench_with_input(
-            BenchmarkId::new("analyze", size),
-            size,
-            |b, &size| {
-                let analyzer = AttractorAnalyzer::new(3, 1);
+        group.bench_with_input(BenchmarkId::new("analyze", size), size, |b, &size| {
+            let analyzer = AttractorAnalyzer::new(3, 1);
 
-                // Generate test data (logistic map)
-                let mut data = Vec::with_capacity(size);
-                let mut x = 0.1;
-                for _ in 0..size {
-                    x = 3.7 * x * (1.0 - x);
-                    data.push(x);
-                }
+            // Generate test data (logistic map)
+            let mut data = Vec::with_capacity(size);
+            let mut x = 0.1;
+            for _ in 0..size {
+                x = 3.7 * x * (1.0 - x);
+                data.push(x);
+            }
 
-                b.iter(|| {
-                    black_box(analyzer.analyze(&data).unwrap())
-                });
-            },
-        );
+            b.iter(|| black_box(analyzer.analyze(&data).unwrap()));
+        });
     }
 
     // Benchmark behavior analysis
@@ -557,9 +546,7 @@ fn benchmark_attractor_analysis(c: &mut Criterion) {
             );
         }
 
-        b.iter(|| {
-            black_box(analyzer.get_behavior_summary())
-        });
+        b.iter(|| black_box(analyzer.get_behavior_summary()));
     });
 
     // Benchmark trajectory prediction
@@ -568,9 +555,7 @@ fn benchmark_attractor_analysis(c: &mut Criterion) {
         let data: Vec<f64> = (0..100).map(|i| (i as f64 * 0.1).sin()).collect();
         let trajectory = Trajectory::from_timeseries(&data, 3, 1);
 
-        b.iter(|| {
-            black_box(analyzer.predict_next(&trajectory))
-        });
+        b.iter(|| black_box(analyzer.predict_next(&trajectory)));
     });
 
     group.finish();
@@ -592,9 +577,7 @@ fn benchmark_temporal_neural(c: &mut Criterion) {
 
         let formula = TemporalFormula::atom("safe");
 
-        b.iter(|| {
-            black_box(solver.verify(&formula, &trace))
-        });
+        b.iter(|| black_box(solver.verify(&formula, &trace)));
     });
 
     // Benchmark eventually operator
@@ -610,9 +593,7 @@ fn benchmark_temporal_neural(c: &mut Criterion) {
 
         let formula = TemporalFormula::eventually(TemporalFormula::atom("goal"));
 
-        b.iter(|| {
-            black_box(solver.verify(&formula, &trace))
-        });
+        b.iter(|| black_box(solver.verify(&formula, &trace)));
     });
 
     // Benchmark globally operator
@@ -628,9 +609,7 @@ fn benchmark_temporal_neural(c: &mut Criterion) {
 
         let formula = TemporalFormula::globally(TemporalFormula::atom("invariant"));
 
-        b.iter(|| {
-            black_box(solver.verify(&formula, &trace))
-        });
+        b.iter(|| black_box(solver.verify(&formula, &trace)));
     });
 
     // Benchmark complex formulas
@@ -646,16 +625,12 @@ fn benchmark_temporal_neural(c: &mut Criterion) {
         }
 
         // G(request -> F response)
-        let formula = TemporalFormula::globally(
-            TemporalFormula::implies(
-                TemporalFormula::atom("request"),
-                TemporalFormula::eventually(TemporalFormula::atom("response"))
-            )
-        );
+        let formula = TemporalFormula::globally(TemporalFormula::implies(
+            TemporalFormula::atom("request"),
+            TemporalFormula::eventually(TemporalFormula::atom("response")),
+        ));
 
-        b.iter(|| {
-            black_box(solver.verify(&formula, &trace))
-        });
+        b.iter(|| black_box(solver.verify(&formula, &trace)));
     });
 
     // Benchmark MTL (bounded temporal)
@@ -675,9 +650,7 @@ fn benchmark_temporal_neural(c: &mut Criterion) {
             std::time::Duration::from_millis(600),
         );
 
-        b.iter(|| {
-            black_box(solver.verify(&formula, &trace))
-        });
+        b.iter(|| black_box(solver.verify(&formula, &trace)));
     });
 
     group.finish();
@@ -748,9 +721,7 @@ fn benchmark_meta_learning(c: &mut Criterion) {
     group.bench_function("safety_check", |b| {
         let learner = MetaLearner::new(100);
 
-        b.iter(|| {
-            black_box(learner.safety_check())
-        });
+        b.iter(|| black_box(learner.safety_check()));
     });
 
     // Benchmark meta-level transitions

--- a/benches/meta_bench.rs
+++ b/benches/meta_bench.rs
@@ -14,10 +14,9 @@
 //! - Iteration speed: >1000 iterations/second
 //! - Safety overhead: <5% performance impact
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId, Throughput};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use midstreamer_strange_loop::{
-    StrangeLoop, StrangeLoopConfig, MetaLevel, MetaKnowledge,
-    SafetyConstraint, ModificationRule,
+    MetaKnowledge, MetaLevel, ModificationRule, SafetyConstraint, StrangeLoop, StrangeLoopConfig,
 };
 
 // ============================================================================
@@ -28,9 +27,7 @@ fn generate_pattern_data(size: usize, complexity: &str) -> Vec<String> {
     match complexity {
         "simple" => {
             // Highly repetitive patterns
-            (0..size)
-                .map(|i| format!("pattern{}", i % 10))
-                .collect()
+            (0..size).map(|i| format!("pattern{}", i % 10)).collect()
         }
         "medium" => {
             // Moderate repetition with variations
@@ -109,21 +106,16 @@ fn bench_pattern_extraction_simple(c: &mut Criterion) {
     for size in [100, 500, 1000, 2000, 5000].iter() {
         group.throughput(Throughput::Elements(*size as u64));
 
-        group.bench_with_input(
-            BenchmarkId::new("simple_patterns", size),
-            size,
-            |b, &n| {
-                let data = generate_pattern_data(n, "simple");
-                let mut strange_loop = StrangeLoop::default();
+        group.bench_with_input(BenchmarkId::new("simple_patterns", size), size, |b, &n| {
+            let data = generate_pattern_data(n, "simple");
+            let mut strange_loop = StrangeLoop::default();
 
-                b.iter(|| {
-                    black_box(strange_loop.learn_at_level(
-                        black_box(MetaLevel::base()),
-                        black_box(&data)
-                    ))
-                });
-            }
-        );
+            b.iter(|| {
+                black_box(
+                    strange_loop.learn_at_level(black_box(MetaLevel::base()), black_box(&data)),
+                )
+            });
+        });
     }
 
     group.finish();
@@ -143,12 +135,11 @@ fn bench_pattern_extraction_complexity(c: &mut Criterion) {
                 let mut strange_loop = StrangeLoop::default();
 
                 b.iter(|| {
-                    black_box(strange_loop.learn_at_level(
-                        black_box(MetaLevel::base()),
-                        black_box(&data)
-                    ))
+                    black_box(
+                        strange_loop.learn_at_level(black_box(MetaLevel::base()), black_box(&data)),
+                    )
                 });
-            }
+            },
         );
     }
 
@@ -164,10 +155,7 @@ fn bench_pattern_extraction_edge_cases(c: &mut Criterion) {
         let mut strange_loop = StrangeLoop::default();
 
         b.iter(|| {
-            black_box(strange_loop.learn_at_level(
-                black_box(MetaLevel::base()),
-                black_box(&data)
-            ))
+            black_box(strange_loop.learn_at_level(black_box(MetaLevel::base()), black_box(&data)))
         });
     });
 
@@ -177,10 +165,7 @@ fn bench_pattern_extraction_edge_cases(c: &mut Criterion) {
         let mut strange_loop = StrangeLoop::default();
 
         b.iter(|| {
-            black_box(strange_loop.learn_at_level(
-                black_box(MetaLevel::base()),
-                black_box(&data)
-            ))
+            black_box(strange_loop.learn_at_level(black_box(MetaLevel::base()), black_box(&data)))
         });
     });
 
@@ -192,10 +177,7 @@ fn bench_pattern_extraction_edge_cases(c: &mut Criterion) {
         let mut strange_loop = StrangeLoop::default();
 
         b.iter(|| {
-            black_box(strange_loop.learn_at_level(
-                black_box(MetaLevel::base()),
-                black_box(&data)
-            ))
+            black_box(strange_loop.learn_at_level(black_box(MetaLevel::base()), black_box(&data)))
         });
     });
 
@@ -210,24 +192,19 @@ fn bench_recursive_depth_scaling(c: &mut Criterion) {
     let mut group = c.benchmark_group("recursive_depth");
 
     for depth in [1, 3, 5, 10, 15].iter() {
-        group.bench_with_input(
-            BenchmarkId::new("depth", depth),
-            depth,
-            |b, &d| {
-                let mut config = StrangeLoopConfig::default();
-                config.max_meta_depth = d;
-                let mut strange_loop = StrangeLoop::new(config);
-                let data = generate_pattern_data(100, "simple");
+        group.bench_with_input(BenchmarkId::new("depth", depth), depth, |b, &d| {
+            let mut config = StrangeLoopConfig::default();
+            config.max_meta_depth = d;
+            let mut strange_loop = StrangeLoop::new(config);
+            let data = generate_pattern_data(100, "simple");
 
-                b.iter(|| {
-                    strange_loop.reset();
-                    black_box(strange_loop.learn_at_level(
-                        black_box(MetaLevel::base()),
-                        black_box(&data)
-                    ))
-                });
-            }
-        );
+            b.iter(|| {
+                strange_loop.reset();
+                black_box(
+                    strange_loop.learn_at_level(black_box(MetaLevel::base()), black_box(&data)),
+                )
+            });
+        });
     }
 
     group.finish();
@@ -245,10 +222,7 @@ fn bench_recursive_depth_stress(c: &mut Criterion) {
 
         b.iter(|| {
             strange_loop.reset();
-            black_box(strange_loop.learn_at_level(
-                black_box(MetaLevel::base()),
-                black_box(&data)
-            ))
+            black_box(strange_loop.learn_at_level(black_box(MetaLevel::base()), black_box(&data)))
         });
     });
 
@@ -261,10 +235,7 @@ fn bench_recursive_depth_stress(c: &mut Criterion) {
 
         b.iter(|| {
             strange_loop.reset();
-            black_box(strange_loop.learn_at_level(
-                black_box(MetaLevel::base()),
-                black_box(&data)
-            ))
+            black_box(strange_loop.learn_at_level(black_box(MetaLevel::base()), black_box(&data)))
         });
     });
 
@@ -277,10 +248,7 @@ fn bench_recursive_depth_stress(c: &mut Criterion) {
 
         b.iter(|| {
             strange_loop.reset();
-            black_box(strange_loop.learn_at_level(
-                black_box(MetaLevel::base()),
-                black_box(&data)
-            ))
+            black_box(strange_loop.learn_at_level(black_box(MetaLevel::base()), black_box(&data)))
         });
     });
 
@@ -300,10 +268,7 @@ fn bench_meta_learning_iterations(c: &mut Criterion) {
         let mut strange_loop = StrangeLoop::default();
 
         b.iter(|| {
-            black_box(strange_loop.learn_at_level(
-                black_box(MetaLevel::base()),
-                black_box(&data)
-            ))
+            black_box(strange_loop.learn_at_level(black_box(MetaLevel::base()), black_box(&data)))
         });
     });
 
@@ -320,13 +285,14 @@ fn bench_meta_learning_iterations(c: &mut Criterion) {
                 b.iter(|| {
                     let mut strange_loop = StrangeLoop::default();
                     for _ in 0..n {
-                        black_box(strange_loop.learn_at_level(
-                            black_box(MetaLevel::base()),
-                            black_box(&data)
-                        )).ok();
+                        black_box(
+                            strange_loop
+                                .learn_at_level(black_box(MetaLevel::base()), black_box(&data)),
+                        )
+                        .ok();
                     }
                 });
-            }
+            },
         );
     }
 
@@ -343,10 +309,9 @@ fn bench_iteration_throughput(c: &mut Criterion) {
         let mut count = 0u64;
 
         b.iter(|| {
-            strange_loop.learn_at_level(
-                black_box(MetaLevel::base()),
-                black_box(&data)
-            ).ok();
+            strange_loop
+                .learn_at_level(black_box(MetaLevel::base()), black_box(&data))
+                .ok();
             count += 1;
             black_box(count)
         });
@@ -360,10 +325,10 @@ fn bench_iteration_throughput(c: &mut Criterion) {
             // Simulate parallel learning at different levels
             let mut strange_loop = StrangeLoop::default();
             for level in 0..3 {
-                black_box(strange_loop.learn_at_level(
-                    black_box(MetaLevel(level)),
-                    black_box(&data)
-                )).ok();
+                black_box(
+                    strange_loop.learn_at_level(black_box(MetaLevel(level)), black_box(&data)),
+                )
+                .ok();
             }
         });
     });
@@ -386,10 +351,7 @@ fn bench_safety_check_overhead(c: &mut Criterion) {
         let data = generate_pattern_data(100, "medium");
 
         b.iter(|| {
-            black_box(strange_loop.learn_at_level(
-                black_box(MetaLevel::base()),
-                black_box(&data)
-            ))
+            black_box(strange_loop.learn_at_level(black_box(MetaLevel::base()), black_box(&data)))
         });
     });
 
@@ -401,10 +363,7 @@ fn bench_safety_check_overhead(c: &mut Criterion) {
         let data = generate_pattern_data(100, "medium");
 
         b.iter(|| {
-            black_box(strange_loop.learn_at_level(
-                black_box(MetaLevel::base()),
-                black_box(&data)
-            ))
+            black_box(strange_loop.learn_at_level(black_box(MetaLevel::base()), black_box(&data)))
         });
     });
 
@@ -418,10 +377,8 @@ fn bench_safety_check_overhead(c: &mut Criterion) {
             config_safe.safety_check_enabled = true;
             let mut safe_loop = StrangeLoop::new(config_safe);
 
-            let safe_result = black_box(safe_loop.learn_at_level(
-                black_box(MetaLevel::base()),
-                black_box(&data)
-            ));
+            let safe_result =
+                black_box(safe_loop.learn_at_level(black_box(MetaLevel::base()), black_box(&data)));
 
             black_box(safe_result)
         });
@@ -439,10 +396,7 @@ fn bench_safety_constraint_validation(c: &mut Criterion) {
         let data = generate_pattern_data(100, "simple");
 
         b.iter(|| {
-            black_box(strange_loop.learn_at_level(
-                black_box(MetaLevel::base()),
-                black_box(&data)
-            ))
+            black_box(strange_loop.learn_at_level(black_box(MetaLevel::base()), black_box(&data)))
         });
     });
 
@@ -452,21 +406,16 @@ fn bench_safety_constraint_validation(c: &mut Criterion) {
 
         // Add multiple safety constraints
         for i in 0..10 {
-            strange_loop.add_safety_constraint(
-                SafetyConstraint::new(
-                    format!("constraint_{}", i),
-                    format!("G(safe_{})", i)
-                )
-            );
+            strange_loop.add_safety_constraint(SafetyConstraint::new(
+                format!("constraint_{}", i),
+                format!("G(safe_{})", i),
+            ));
         }
 
         let data = generate_pattern_data(100, "simple");
 
         b.iter(|| {
-            black_box(strange_loop.learn_at_level(
-                black_box(MetaLevel::base()),
-                black_box(&data)
-            ))
+            black_box(strange_loop.learn_at_level(black_box(MetaLevel::base()), black_box(&data)))
         });
     });
 
@@ -484,9 +433,7 @@ fn bench_rollback_reset(c: &mut Criterion) {
     group.bench_function("reset_empty", |b| {
         let mut strange_loop = StrangeLoop::default();
 
-        b.iter(|| {
-            black_box(strange_loop.reset())
-        });
+        b.iter(|| black_box(strange_loop.reset()));
     });
 
     // Reset after learning
@@ -558,11 +505,7 @@ fn bench_validation_overhead(c: &mut Criterion) {
         let data = generate_pattern_data(1000, "medium");
         strange_loop.learn_at_level(MetaLevel::base(), &data).ok();
 
-        b.iter(|| {
-            black_box(strange_loop.get_knowledge_at_level(
-                black_box(MetaLevel::base())
-            ))
-        });
+        b.iter(|| black_box(strange_loop.get_knowledge_at_level(black_box(MetaLevel::base()))));
     });
 
     // Get all knowledge validation
@@ -575,9 +518,7 @@ fn bench_validation_overhead(c: &mut Criterion) {
             strange_loop.learn_at_level(MetaLevel(level), &data).ok();
         }
 
-        b.iter(|| {
-            black_box(strange_loop.get_all_knowledge())
-        });
+        b.iter(|| black_box(strange_loop.get_all_knowledge()));
     });
 
     // Summary generation
@@ -586,9 +527,7 @@ fn bench_validation_overhead(c: &mut Criterion) {
         let data = generate_pattern_data(1000, "complex");
         strange_loop.learn_at_level(MetaLevel::base(), &data).ok();
 
-        b.iter(|| {
-            black_box(strange_loop.get_summary())
-        });
+        b.iter(|| black_box(strange_loop.get_summary()));
     });
 
     group.finish();
@@ -611,10 +550,8 @@ fn bench_complete_meta_learning_pipeline(c: &mut Criterion) {
             let mut strange_loop = StrangeLoop::new(config);
 
             // Learn at base level (triggers recursive learning)
-            let result = strange_loop.learn_at_level(
-                black_box(MetaLevel::base()),
-                black_box(&data)
-            );
+            let result =
+                strange_loop.learn_at_level(black_box(MetaLevel::base()), black_box(&data));
 
             // Get summary
             let summary = strange_loop.get_summary();
@@ -634,10 +571,9 @@ fn bench_complete_meta_learning_pipeline(c: &mut Criterion) {
 
             // Learn at multiple levels explicitly
             for level in 0..3 {
-                strange_loop.learn_at_level(
-                    black_box(MetaLevel(level)),
-                    black_box(&data)
-                ).ok();
+                strange_loop
+                    .learn_at_level(black_box(MetaLevel(level)), black_box(&data))
+                    .ok();
             }
 
             black_box(strange_loop.get_summary())
@@ -660,10 +596,7 @@ fn bench_memory_efficiency(c: &mut Criterion) {
         let mut strange_loop = StrangeLoop::default();
 
         b.iter(|| {
-            black_box(strange_loop.learn_at_level(
-                black_box(MetaLevel::base()),
-                black_box(&data)
-            ))
+            black_box(strange_loop.learn_at_level(black_box(MetaLevel::base()), black_box(&data)))
         });
     });
 
@@ -675,10 +608,9 @@ fn bench_memory_efficiency(c: &mut Criterion) {
             let mut strange_loop = StrangeLoop::default();
 
             for _ in 0..10 {
-                strange_loop.learn_at_level(
-                    black_box(MetaLevel::base()),
-                    black_box(&data)
-                ).ok();
+                strange_loop
+                    .learn_at_level(black_box(MetaLevel::base()), black_box(&data))
+                    .ok();
             }
 
             black_box(strange_loop.get_summary())

--- a/benches/quic_bench.rs
+++ b/benches/quic_bench.rs
@@ -56,11 +56,7 @@ mod mock {
     }
 
     impl MockStream {
-        fn new(
-            bytes_sent: Arc<AtomicU64>,
-            bytes_received: Arc<AtomicU64>,
-            rtt_us: u64,
-        ) -> Self {
+        fn new(bytes_sent: Arc<AtomicU64>, bytes_received: Arc<AtomicU64>, rtt_us: u64) -> Self {
             Self {
                 bytes_sent,
                 bytes_received,
@@ -71,7 +67,8 @@ mod mock {
         pub async fn send(&mut self, data: &[u8]) -> Result<usize, String> {
             // Simulate network delay
             tokio::time::sleep(tokio::time::Duration::from_micros(self.rtt_us / 2)).await;
-            self.bytes_sent.fetch_add(data.len() as u64, Ordering::Relaxed);
+            self.bytes_sent
+                .fetch_add(data.len() as u64, Ordering::Relaxed);
             Ok(data.len())
         }
 
@@ -79,8 +76,7 @@ mod mock {
             // Simulate network delay
             tokio::time::sleep(tokio::time::Duration::from_micros(self.rtt_us / 2)).await;
             let len = buf.len().min(8192); // Simulate typical packet size
-            self.bytes_received
-                .fetch_add(len as u64, Ordering::Relaxed);
+            self.bytes_received.fetch_add(len as u64, Ordering::Relaxed);
             Ok(len)
         }
 

--- a/benches/scheduler_bench.rs
+++ b/benches/scheduler_bench.rs
@@ -13,14 +13,13 @@
 //! - Task execution: <1μs
 //! - Stats calculation: <10μs
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId, Throughput};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use midstreamer_scheduler::{
-    NanoScheduler, Task, TaskPriority, ScheduleResult,
-    stats::SchedulerStats,
+    stats::SchedulerStats, NanoScheduler, ScheduleResult, Task, TaskPriority,
 };
-use std::time::{Duration, Instant};
 use std::sync::{Arc, Mutex};
 use std::thread;
+use std::time::{Duration, Instant};
 
 // ============================================================================
 // Test Task Generators
@@ -114,7 +113,7 @@ fn bench_schedule_overhead(c: &mut Criterion) {
                         black_box(scheduler.schedule(black_box(task)));
                     }
                 });
-            }
+            },
         );
     }
 
@@ -222,7 +221,7 @@ fn bench_execution_throughput(c: &mut Criterion) {
                         scheduler.run_once();
                     }
                 });
-            }
+            },
         );
     }
 
@@ -326,9 +325,7 @@ fn bench_statistics_overhead(c: &mut Criterion) {
             scheduler.run_once();
         }
 
-        b.iter(|| {
-            black_box(scheduler.get_stats())
-        });
+        b.iter(|| black_box(scheduler.get_stats()));
     });
 
     // Stats calculation with varying history sizes
@@ -348,10 +345,8 @@ fn bench_statistics_overhead(c: &mut Criterion) {
                     scheduler.run_once();
                 }
 
-                b.iter(|| {
-                    black_box(scheduler.get_stats())
-                });
-            }
+                b.iter(|| black_box(scheduler.get_stats()));
+            },
         );
     }
 
@@ -378,10 +373,7 @@ fn bench_multithreaded_scheduling(c: &mut Criterion) {
                         let scheduler = Arc::clone(&scheduler);
                         let handle = thread::spawn(move || {
                             for i in 0..100 {
-                                let task = create_compute_task(
-                                    thread_id as u64 * 100 + i,
-                                    100
-                                );
+                                let task = create_compute_task(thread_id as u64 * 100 + i, 100);
                                 scheduler.lock().unwrap().schedule(task);
                             }
                         });
@@ -397,7 +389,7 @@ fn bench_multithreaded_scheduling(c: &mut Criterion) {
                         scheduler.run_once();
                     }
                 });
-            }
+            },
         );
     }
 

--- a/benches/temporal_bench.rs
+++ b/benches/temporal_bench.rs
@@ -12,12 +12,10 @@
 //! - LCS n=100: <5ms
 //! - Edit distance n=100: <3ms
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId, Throughput};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use midstreamer_temporal_compare::{
-    TemporalCompare, TemporalData, TemporalPattern, CachedCompare,
-    dtw::dtw_distance,
-    lcs::longest_common_subsequence,
-    edit::edit_distance,
+    dtw::dtw_distance, edit::edit_distance, lcs::longest_common_subsequence, CachedCompare,
+    TemporalCompare, TemporalData, TemporalPattern,
 };
 
 // ============================================================================
@@ -64,52 +62,25 @@ fn bench_dtw_various_sizes(c: &mut Criterion) {
         group.throughput(Throughput::Elements(*size as u64));
 
         // Linear sequences
-        group.bench_with_input(
-            BenchmarkId::new("linear", size),
-            size,
-            |b, &size| {
-                let seq1 = generate_sequence(size, "linear");
-                let seq2 = generate_similar_sequence(&seq1, 0.9);
-                b.iter(|| {
-                    black_box(dtw_distance(
-                        black_box(&seq1),
-                        black_box(&seq2)
-                    ))
-                });
-            }
-        );
+        group.bench_with_input(BenchmarkId::new("linear", size), size, |b, &size| {
+            let seq1 = generate_sequence(size, "linear");
+            let seq2 = generate_similar_sequence(&seq1, 0.9);
+            b.iter(|| black_box(dtw_distance(black_box(&seq1), black_box(&seq2))));
+        });
 
         // Sine wave sequences
-        group.bench_with_input(
-            BenchmarkId::new("sine", size),
-            size,
-            |b, &size| {
-                let seq1 = generate_sequence(size, "sine");
-                let seq2 = generate_similar_sequence(&seq1, 0.9);
-                b.iter(|| {
-                    black_box(dtw_distance(
-                        black_box(&seq1),
-                        black_box(&seq2)
-                    ))
-                });
-            }
-        );
+        group.bench_with_input(BenchmarkId::new("sine", size), size, |b, &size| {
+            let seq1 = generate_sequence(size, "sine");
+            let seq2 = generate_similar_sequence(&seq1, 0.9);
+            b.iter(|| black_box(dtw_distance(black_box(&seq1), black_box(&seq2))));
+        });
 
         // Random sequences (worst case)
-        group.bench_with_input(
-            BenchmarkId::new("random", size),
-            size,
-            |b, &size| {
-                let seq1 = generate_sequence(size, "random");
-                let seq2 = generate_sequence(size, "random");
-                b.iter(|| {
-                    black_box(dtw_distance(
-                        black_box(&seq1),
-                        black_box(&seq2)
-                    ))
-                });
-            }
-        );
+        group.bench_with_input(BenchmarkId::new("random", size), size, |b, &size| {
+            let seq1 = generate_sequence(size, "random");
+            let seq2 = generate_sequence(size, "random");
+            b.iter(|| black_box(dtw_distance(black_box(&seq1), black_box(&seq2))));
+        });
     }
 
     group.finish();
@@ -126,13 +97,8 @@ fn bench_dtw_similarity_variations(c: &mut Criterion) {
             similarity,
             |b, &sim| {
                 let seq2 = generate_similar_sequence(&base_seq, sim);
-                b.iter(|| {
-                    black_box(dtw_distance(
-                        black_box(&base_seq),
-                        black_box(&seq2)
-                    ))
-                });
-            }
+                b.iter(|| black_box(dtw_distance(black_box(&base_seq), black_box(&seq2))));
+            },
         );
     }
 
@@ -149,49 +115,32 @@ fn bench_lcs_various_sizes(c: &mut Criterion) {
     for size in [10, 50, 100, 500, 1000].iter() {
         group.throughput(Throughput::Elements(*size as u64));
 
-        group.bench_with_input(
-            BenchmarkId::new("identical", size),
-            size,
-            |b, &size| {
-                let seq = generate_string_sequence(size, 26);
-                b.iter(|| {
-                    black_box(longest_common_subsequence(
-                        black_box(&seq),
-                        black_box(&seq)
-                    ))
-                });
-            }
-        );
+        group.bench_with_input(BenchmarkId::new("identical", size), size, |b, &size| {
+            let seq = generate_string_sequence(size, 26);
+            b.iter(|| black_box(longest_common_subsequence(black_box(&seq), black_box(&seq))));
+        });
 
-        group.bench_with_input(
-            BenchmarkId::new("similar", size),
-            size,
-            |b, &size| {
-                let seq1 = generate_string_sequence(size, 26);
-                let seq2 = generate_string_sequence(size + 10, 26);
-                b.iter(|| {
-                    black_box(longest_common_subsequence(
-                        black_box(&seq1),
-                        black_box(&seq2)
-                    ))
-                });
-            }
-        );
+        group.bench_with_input(BenchmarkId::new("similar", size), size, |b, &size| {
+            let seq1 = generate_string_sequence(size, 26);
+            let seq2 = generate_string_sequence(size + 10, 26);
+            b.iter(|| {
+                black_box(longest_common_subsequence(
+                    black_box(&seq1),
+                    black_box(&seq2),
+                ))
+            });
+        });
 
-        group.bench_with_input(
-            BenchmarkId::new("different", size),
-            size,
-            |b, &size| {
-                let seq1 = generate_string_sequence(size, 4);
-                let seq2 = generate_string_sequence(size, 4);
-                b.iter(|| {
-                    black_box(longest_common_subsequence(
-                        black_box(&seq1),
-                        black_box(&seq2)
-                    ))
-                });
-            }
-        );
+        group.bench_with_input(BenchmarkId::new("different", size), size, |b, &size| {
+            let seq1 = generate_string_sequence(size, 4);
+            let seq2 = generate_string_sequence(size, 4);
+            b.iter(|| {
+                black_box(longest_common_subsequence(
+                    black_box(&seq1),
+                    black_box(&seq2),
+                ))
+            });
+        });
     }
 
     group.finish();
@@ -213,13 +162,8 @@ fn bench_edit_distance_various_sizes(c: &mut Criterion) {
             |b, &size| {
                 let seq1 = generate_string_sequence(size, 4);
                 let seq2 = generate_string_sequence(size + 5, 4);
-                b.iter(|| {
-                    black_box(edit_distance(
-                        black_box(&seq1),
-                        black_box(&seq2)
-                    ))
-                });
-            }
+                b.iter(|| black_box(edit_distance(black_box(&seq1), black_box(&seq2))));
+            },
         );
 
         group.bench_with_input(
@@ -228,13 +172,8 @@ fn bench_edit_distance_various_sizes(c: &mut Criterion) {
             |b, &size| {
                 let seq1 = generate_string_sequence(size, 26);
                 let seq2 = generate_string_sequence(size + 5, 26);
-                b.iter(|| {
-                    black_box(edit_distance(
-                        black_box(&seq1),
-                        black_box(&seq2)
-                    ))
-                });
-            }
+                b.iter(|| black_box(edit_distance(black_box(&seq1), black_box(&seq2))));
+            },
         );
     }
 
@@ -252,12 +191,7 @@ fn bench_edit_distance_operations(c: &mut Criterion) {
         for i in (0..20).rev() {
             modified.insert(i * 5, 'X');
         }
-        b.iter(|| {
-            black_box(edit_distance(
-                black_box(&base),
-                black_box(&modified)
-            ))
-        });
+        b.iter(|| black_box(edit_distance(black_box(&base), black_box(&modified))));
     });
 
     // Deletion heavy
@@ -268,12 +202,7 @@ fn bench_edit_distance_operations(c: &mut Criterion) {
                 modified.remove(modified.len() / 2);
             }
         }
-        b.iter(|| {
-            black_box(edit_distance(
-                black_box(&base),
-                black_box(&modified)
-            ))
-        });
+        b.iter(|| black_box(edit_distance(black_box(&base), black_box(&modified))));
     });
 
     // Substitution heavy
@@ -284,12 +213,7 @@ fn bench_edit_distance_operations(c: &mut Criterion) {
                 modified[i] = 'Z';
             }
         }
-        b.iter(|| {
-            black_box(edit_distance(
-                black_box(&base),
-                black_box(&modified)
-            ))
-        });
+        b.iter(|| black_box(edit_distance(black_box(&base), black_box(&modified))));
     });
 
     group.finish();
@@ -311,12 +235,7 @@ fn bench_cache_scenarios(c: &mut Criterion) {
         // Warm up cache
         cache.compare_dtw(&seq1, &seq2);
 
-        b.iter(|| {
-            black_box(cache.compare_dtw(
-                black_box(&seq1),
-                black_box(&seq2)
-            ))
-        });
+        b.iter(|| black_box(cache.compare_dtw(black_box(&seq1), black_box(&seq2))));
     });
 
     // Cache miss scenario
@@ -330,28 +249,20 @@ fn bench_cache_scenarios(c: &mut Criterion) {
         b.iter(|| {
             idx = (idx + 1) % sequences.len();
             let idx2 = (idx + 1) % sequences.len();
-            black_box(cache.compare_dtw(
-                black_box(&sequences[idx]),
-                black_box(&sequences[idx2])
-            ))
+            black_box(cache.compare_dtw(black_box(&sequences[idx]), black_box(&sequences[idx2])))
         });
     });
 
     // Cache eviction scenario
     group.bench_function("cache_eviction", |b| {
         let mut cache = CachedCompare::new(50);
-        let sequences: Vec<_> = (0..100)
-            .map(|i| generate_sequence(100, "sine"))
-            .collect();
+        let sequences: Vec<_> = (0..100).map(|i| generate_sequence(100, "sine")).collect();
 
         let mut idx = 0;
         b.iter(|| {
             idx = (idx + 1) % sequences.len();
             let idx2 = (idx + 1) % sequences.len();
-            black_box(cache.compare_dtw(
-                black_box(&sequences[idx]),
-                black_box(&sequences[idx2])
-            ))
+            black_box(cache.compare_dtw(black_box(&sequences[idx]), black_box(&sequences[idx2])))
         });
     });
 

--- a/crates/nanosecond-scheduler/src/lib.rs
+++ b/crates/nanosecond-scheduler/src/lib.rs
@@ -9,12 +9,12 @@
 //! - Lock-free queues for performance
 //! - CPU affinity support
 
+use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
-use std::collections::BinaryHeap;
 use std::cmp::Ordering;
+use std::collections::BinaryHeap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use parking_lot::RwLock;
 use thiserror::Error;
 
 /// Scheduler errors
@@ -152,8 +152,12 @@ impl<T> Ord for ScheduledTask<T> {
         // max-heap, the LATER deadline is "greater" by default, but
         // we want EARLIER deadlines first. So we *do* swap the
         // deadline comparison.
-        self.priority.cmp(&other.priority)
-            .then_with(|| other.deadline.absolute_time.cmp(&self.deadline.absolute_time))
+        self.priority.cmp(&other.priority).then_with(|| {
+            other
+                .deadline
+                .absolute_time
+                .cmp(&self.deadline.absolute_time)
+        })
     }
 }
 
@@ -353,11 +357,9 @@ mod tests {
     fn test_schedule_task() {
         let scheduler = RealtimeScheduler::default();
 
-        let task_id = scheduler.schedule(
-            42,
-            Deadline::from_millis(100),
-            Priority::High,
-        ).unwrap();
+        let task_id = scheduler
+            .schedule(42, Deadline::from_millis(100), Priority::High)
+            .unwrap();
 
         assert_eq!(task_id, 1);
         assert_eq!(scheduler.queue_size(), 1);
@@ -367,9 +369,15 @@ mod tests {
     fn test_priority_ordering() {
         let scheduler = RealtimeScheduler::default();
 
-        scheduler.schedule(1, Deadline::from_millis(100), Priority::Low).unwrap();
-        scheduler.schedule(2, Deadline::from_millis(100), Priority::High).unwrap();
-        scheduler.schedule(3, Deadline::from_millis(100), Priority::Critical).unwrap();
+        scheduler
+            .schedule(1, Deadline::from_millis(100), Priority::Low)
+            .unwrap();
+        scheduler
+            .schedule(2, Deadline::from_millis(100), Priority::High)
+            .unwrap();
+        scheduler
+            .schedule(3, Deadline::from_millis(100), Priority::Critical)
+            .unwrap();
 
         let task1 = scheduler.next_task().unwrap();
         assert_eq!(task1.payload, 3); // Critical priority
@@ -388,7 +396,9 @@ mod tests {
         let past_deadline = Deadline::from_micros(1); // Very short deadline
         std::thread::sleep(Duration::from_millis(10));
 
-        scheduler.schedule(42, past_deadline, Priority::High).unwrap();
+        scheduler
+            .schedule(42, past_deadline, Priority::High)
+            .unwrap();
 
         let task = scheduler.next_task().unwrap();
         assert!(task.deadline.is_passed());
@@ -398,7 +408,9 @@ mod tests {
     fn test_execute_task() {
         let scheduler = RealtimeScheduler::default();
 
-        scheduler.schedule(42, Deadline::from_millis(100), Priority::High).unwrap();
+        scheduler
+            .schedule(42, Deadline::from_millis(100), Priority::High)
+            .unwrap();
 
         let task = scheduler.next_task().unwrap();
         scheduler.execute_task(task, |payload| {
@@ -414,7 +426,9 @@ mod tests {
         let scheduler = RealtimeScheduler::default();
 
         for i in 0..10 {
-            scheduler.schedule(i, Deadline::from_millis(100), Priority::Medium).unwrap();
+            scheduler
+                .schedule(i, Deadline::from_millis(100), Priority::Medium)
+                .unwrap();
         }
 
         let stats = scheduler.stats();

--- a/crates/nanosecond-scheduler/tests/proptest_queue_order.rs
+++ b/crates/nanosecond-scheduler/tests/proptest_queue_order.rs
@@ -41,10 +41,7 @@ fn priority(idx: u8) -> Priority {
 
 /// Generator: a vector of `(priority_idx, deadline_micros, payload)`.
 fn task_specs() -> impl Strategy<Value = Vec<(u8, u64, u32)>> {
-    proptest::collection::vec(
-        (0u8..=4, 1u64..=1_000_000, any::<u32>()),
-        0..=32,
-    )
+    proptest::collection::vec((0u8..=4, 1u64..=1_000_000, any::<u32>()), 0..=32)
 }
 
 fn fresh_scheduler(max_queue_size: usize) -> RealtimeScheduler<u32> {

--- a/crates/quic-multistream/src/lib.rs
+++ b/crates/quic-multistream/src/lib.rs
@@ -55,7 +55,6 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use thiserror::Error;
 
-
 #[cfg(not(target_arch = "wasm32"))]
 mod native;
 
@@ -131,8 +130,7 @@ impl From<wasm_bindgen::JsValue> for QuicError {
 }
 
 /// Stream priority for quality-of-service control
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
-#[derive(Default)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub enum StreamPriority {
     /// Critical priority (highest)
     Critical = 0,
@@ -144,7 +142,6 @@ pub enum StreamPriority {
     /// Low priority
     Low = 3,
 }
-
 
 impl fmt::Display for StreamPriority {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/quic-multistream/src/native.rs
+++ b/crates/quic-multistream/src/native.rs
@@ -3,8 +3,8 @@
 use crate::{ConnectionStats, QuicError, StreamPriority};
 use quinn::{ClientConfig, Endpoint, RecvStream, SendStream, VarInt};
 use std::net::{SocketAddr, ToSocketAddrs};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 /// QUIC connection wrapper for native targets
 pub struct QuicConnection {
@@ -130,7 +130,8 @@ impl QuicConnection {
 
     /// Close the connection
     pub fn close(&self, error_code: u64, reason: &[u8]) {
-        self.connection.close(VarInt::from_u64(error_code).unwrap(), reason);
+        self.connection
+            .close(VarInt::from_u64(error_code).unwrap(), reason);
     }
 
     /// Get the remote address
@@ -167,7 +168,8 @@ impl QuicStream {
     /// Send data on the stream
     pub async fn send(&mut self, data: &[u8]) -> Result<usize, QuicError> {
         self.send.write_all(data).await?;
-        self.bytes_sent.fetch_add(data.len() as u64, Ordering::Relaxed);
+        self.bytes_sent
+            .fetch_add(data.len() as u64, Ordering::Relaxed);
         Ok(data.len())
     }
 
@@ -180,7 +182,8 @@ impl QuicStream {
 
     /// Finish sending on this stream
     pub async fn finish(&mut self) -> Result<(), QuicError> {
-        self.send.finish()
+        self.send
+            .finish()
             .map_err(|e| QuicError::StreamError(format!("Failed to finish stream: {:?}", e)))?;
         Ok(())
     }
@@ -212,13 +215,15 @@ impl QuicSendStream {
     /// Send data on the stream
     pub async fn send(&mut self, data: &[u8]) -> Result<usize, QuicError> {
         self.send.write_all(data).await?;
-        self.bytes_sent.fetch_add(data.len() as u64, Ordering::Relaxed);
+        self.bytes_sent
+            .fetch_add(data.len() as u64, Ordering::Relaxed);
         Ok(data.len())
     }
 
     /// Finish sending on this stream
     pub async fn finish(&mut self) -> Result<(), QuicError> {
-        self.send.finish()
+        self.send
+            .finish()
             .map_err(|e| QuicError::StreamError(format!("Failed to finish stream: {:?}", e)))?;
         Ok(())
     }

--- a/crates/strange-loop/benches/meta_bench.rs
+++ b/crates/strange-loop/benches/meta_bench.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use midstreamer_strange_loop::*;
 
 /// Benchmark pattern extraction performance with varying data sizes
@@ -14,7 +14,8 @@ fn pattern_extraction_benchmark(c: &mut Criterion) {
 
             b.iter(|| {
                 let mut strange_loop = StrangeLoop::default();
-                let result = strange_loop.learn_at_level(black_box(MetaLevel::base()), black_box(&data));
+                let result =
+                    strange_loop.learn_at_level(black_box(MetaLevel::base()), black_box(&data));
                 result.unwrap()
             });
         });
@@ -46,7 +47,8 @@ fn recursive_optimization_benchmark(c: &mut Criterion) {
                 let mut strange_loop = StrangeLoop::new(black_box(config.clone()));
 
                 // Learn at base level, which will trigger recursive meta-learning
-                let result = strange_loop.learn_at_level(black_box(MetaLevel::base()), black_box(&data));
+                let result =
+                    strange_loop.learn_at_level(black_box(MetaLevel::base()), black_box(&data));
                 result.unwrap()
             });
         });
@@ -60,30 +62,34 @@ fn self_modification_overhead_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("self_modification_overhead");
 
     for num_modifications in [1, 5, 10, 20].iter() {
-        group.bench_with_input(BenchmarkId::from_parameter(num_modifications), num_modifications, |b, &num_modifications| {
-            let config = StrangeLoopConfig {
-                max_meta_depth: 3,
-                enable_self_modification: true,
-                max_modifications_per_cycle: 100,
-                safety_check_enabled: true,
-            };
+        group.bench_with_input(
+            BenchmarkId::from_parameter(num_modifications),
+            num_modifications,
+            |b, &num_modifications| {
+                let config = StrangeLoopConfig {
+                    max_meta_depth: 3,
+                    enable_self_modification: true,
+                    max_modifications_per_cycle: 100,
+                    safety_check_enabled: true,
+                };
 
-            b.iter(|| {
-                let mut strange_loop = StrangeLoop::new(black_box(config.clone()));
+                b.iter(|| {
+                    let mut strange_loop = StrangeLoop::new(black_box(config.clone()));
 
-                for i in 0..num_modifications {
-                    let rule = ModificationRule::new(
-                        format!("rule_{}", i),
-                        format!("trigger_{}", i),
-                        format!("action_{}", i),
-                    );
+                    for i in 0..num_modifications {
+                        let rule = ModificationRule::new(
+                            format!("rule_{}", i),
+                            format!("trigger_{}", i),
+                            format!("action_{}", i),
+                        );
 
-                    let _ = strange_loop.apply_modification(black_box(rule));
-                }
+                        let _ = strange_loop.apply_modification(black_box(rule));
+                    }
 
-                strange_loop.get_summary()
-            });
-        });
+                    strange_loop.get_summary()
+                });
+            },
+        );
     }
 
     group.finish();
@@ -95,28 +101,33 @@ fn meta_learning_convergence_benchmark(c: &mut Criterion) {
 
     // Test convergence with different numbers of learning iterations
     for iterations in [1, 5, 10, 20, 50].iter() {
-        group.bench_with_input(BenchmarkId::from_parameter(iterations), iterations, |b, &iterations| {
-            let config = StrangeLoopConfig {
-                max_meta_depth: 2,
-                enable_self_modification: false,
-                max_modifications_per_cycle: 5,
-                safety_check_enabled: true,
-            };
+        group.bench_with_input(
+            BenchmarkId::from_parameter(iterations),
+            iterations,
+            |b, &iterations| {
+                let config = StrangeLoopConfig {
+                    max_meta_depth: 2,
+                    enable_self_modification: false,
+                    max_modifications_per_cycle: 5,
+                    safety_check_enabled: true,
+                };
 
-            b.iter(|| {
-                let mut strange_loop = StrangeLoop::new(black_box(config.clone()));
+                b.iter(|| {
+                    let mut strange_loop = StrangeLoop::new(black_box(config.clone()));
 
-                for i in 0..iterations {
-                    let data: Vec<String> = (0..50)
-                        .map(|j| format!("iteration_{}_pattern_{}", i, j % 10))
-                        .collect();
+                    for i in 0..iterations {
+                        let data: Vec<String> = (0..50)
+                            .map(|j| format!("iteration_{}_pattern_{}", i, j % 10))
+                            .collect();
 
-                    let _ = strange_loop.learn_at_level(black_box(MetaLevel::base()), black_box(&data));
-                }
+                        let _ = strange_loop
+                            .learn_at_level(black_box(MetaLevel::base()), black_box(&data));
+                    }
 
-                strange_loop.get_summary()
-            });
-        });
+                    strange_loop.get_summary()
+                });
+            },
+        );
     }
 
     group.finish();
@@ -129,27 +140,32 @@ fn memory_usage_recursion_benchmark(c: &mut Criterion) {
     // Test memory usage with different meta-depths and data sizes
     for (depth, data_size) in [(1, 100), (2, 100), (3, 100), (2, 500), (2, 1000)].iter() {
         let label = format!("depth_{}_size_{}", depth, data_size);
-        group.bench_with_input(BenchmarkId::new("recursive_learning", &label), &(depth, data_size), |b, &(depth, data_size)| {
-            let config = StrangeLoopConfig {
-                max_meta_depth: *depth,
-                enable_self_modification: false,
-                max_modifications_per_cycle: 5,
-                safety_check_enabled: true,
-            };
+        group.bench_with_input(
+            BenchmarkId::new("recursive_learning", &label),
+            &(depth, data_size),
+            |b, &(depth, data_size)| {
+                let config = StrangeLoopConfig {
+                    max_meta_depth: *depth,
+                    enable_self_modification: false,
+                    max_modifications_per_cycle: 5,
+                    safety_check_enabled: true,
+                };
 
-            let data: Vec<String> = (0..*data_size)
-                .map(|i| format!("pattern_{}", i % 20))
-                .collect();
+                let data: Vec<String> = (0..*data_size)
+                    .map(|i| format!("pattern_{}", i % 20))
+                    .collect();
 
-            b.iter(|| {
-                let mut strange_loop = StrangeLoop::new(black_box(config.clone()));
-                let _ = strange_loop.learn_at_level(black_box(MetaLevel::base()), black_box(&data));
+                b.iter(|| {
+                    let mut strange_loop = StrangeLoop::new(black_box(config.clone()));
+                    let _ =
+                        strange_loop.learn_at_level(black_box(MetaLevel::base()), black_box(&data));
 
-                // Get all knowledge to measure memory usage
-                let all_knowledge = strange_loop.get_all_knowledge();
-                black_box(all_knowledge)
-            });
-        });
+                    // Get all knowledge to measure memory usage
+                    let all_knowledge = strange_loop.get_all_knowledge();
+                    black_box(all_knowledge)
+                });
+            },
+        );
     }
 
     group.finish();
@@ -161,30 +177,35 @@ fn strategy_adaptation_speed_benchmark(c: &mut Criterion) {
 
     // Test how quickly the system adapts to new patterns
     for pattern_change_frequency in [5, 10, 20, 50].iter() {
-        group.bench_with_input(BenchmarkId::from_parameter(pattern_change_frequency), pattern_change_frequency, |b, &pattern_change_frequency| {
-            let config = StrangeLoopConfig {
-                max_meta_depth: 2,
-                enable_self_modification: false,
-                max_modifications_per_cycle: 5,
-                safety_check_enabled: true,
-            };
+        group.bench_with_input(
+            BenchmarkId::from_parameter(pattern_change_frequency),
+            pattern_change_frequency,
+            |b, &pattern_change_frequency| {
+                let config = StrangeLoopConfig {
+                    max_meta_depth: 2,
+                    enable_self_modification: false,
+                    max_modifications_per_cycle: 5,
+                    safety_check_enabled: true,
+                };
 
-            b.iter(|| {
-                let mut strange_loop = StrangeLoop::new(black_box(config.clone()));
+                b.iter(|| {
+                    let mut strange_loop = StrangeLoop::new(black_box(config.clone()));
 
-                // Simulate changing patterns
-                for batch in 0..10 {
-                    let pattern_base = batch / pattern_change_frequency;
-                    let data: Vec<String> = (0..100)
-                        .map(|i| format!("strategy_{}_pattern_{}", pattern_base, i % 10))
-                        .collect();
+                    // Simulate changing patterns
+                    for batch in 0..10 {
+                        let pattern_base = batch / pattern_change_frequency;
+                        let data: Vec<String> = (0..100)
+                            .map(|i| format!("strategy_{}_pattern_{}", pattern_base, i % 10))
+                            .collect();
 
-                    let _ = strange_loop.learn_at_level(black_box(MetaLevel::base()), black_box(&data));
-                }
+                        let _ = strange_loop
+                            .learn_at_level(black_box(MetaLevel::base()), black_box(&data));
+                    }
 
-                strange_loop.get_summary()
-            });
-        });
+                    strange_loop.get_summary()
+                });
+            },
+        );
     }
 
     group.finish();
@@ -195,33 +216,37 @@ fn safety_constraint_checking_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("safety_constraint_checking");
 
     for num_constraints in [1, 5, 10, 20].iter() {
-        group.bench_with_input(BenchmarkId::from_parameter(num_constraints), num_constraints, |b, &num_constraints| {
-            let config = StrangeLoopConfig {
-                max_meta_depth: 2,
-                enable_self_modification: true,
-                max_modifications_per_cycle: 100,
-                safety_check_enabled: true,
-            };
+        group.bench_with_input(
+            BenchmarkId::from_parameter(num_constraints),
+            num_constraints,
+            |b, &num_constraints| {
+                let config = StrangeLoopConfig {
+                    max_meta_depth: 2,
+                    enable_self_modification: true,
+                    max_modifications_per_cycle: 100,
+                    safety_check_enabled: true,
+                };
 
-            b.iter(|| {
-                let mut strange_loop = StrangeLoop::new(black_box(config.clone()));
+                b.iter(|| {
+                    let mut strange_loop = StrangeLoop::new(black_box(config.clone()));
 
-                // Add multiple safety constraints
-                for i in 0..num_constraints {
-                    let constraint = SafetyConstraint::new(
-                        format!("constraint_{}", i),
-                        format!("G(safe_{})", i),
-                    );
-                    strange_loop.add_safety_constraint(black_box(constraint));
-                }
+                    // Add multiple safety constraints
+                    for i in 0..num_constraints {
+                        let constraint = SafetyConstraint::new(
+                            format!("constraint_{}", i),
+                            format!("G(safe_{})", i),
+                        );
+                        strange_loop.add_safety_constraint(black_box(constraint));
+                    }
 
-                // Try to apply a modification (which triggers safety checks)
-                let rule = ModificationRule::new("test_rule", "test_trigger", "test_action");
-                let _ = strange_loop.apply_modification(black_box(rule));
+                    // Try to apply a modification (which triggers safety checks)
+                    let rule = ModificationRule::new("test_rule", "test_trigger", "test_action");
+                    let _ = strange_loop.apply_modification(black_box(rule));
 
-                strange_loop.get_summary()
-            });
-        });
+                    strange_loop.get_summary()
+                });
+            },
+        );
     }
 
     group.finish();
@@ -232,20 +257,25 @@ fn knowledge_retrieval_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("knowledge_retrieval");
 
     for num_patterns in [10, 50, 100, 500, 1000].iter() {
-        group.bench_with_input(BenchmarkId::from_parameter(num_patterns), num_patterns, |b, &num_patterns| {
-            // Setup: create strange loop with learned knowledge
-            let mut strange_loop = StrangeLoop::default();
-            let data: Vec<String> = (0..num_patterns)
-                .map(|i| format!("pattern_{}", i % 20))
-                .collect();
-            let _ = strange_loop.learn_at_level(MetaLevel::base(), &data);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(num_patterns),
+            num_patterns,
+            |b, &num_patterns| {
+                // Setup: create strange loop with learned knowledge
+                let mut strange_loop = StrangeLoop::default();
+                let data: Vec<String> = (0..num_patterns)
+                    .map(|i| format!("pattern_{}", i % 20))
+                    .collect();
+                let _ = strange_loop.learn_at_level(MetaLevel::base(), &data);
 
-            b.iter(|| {
-                // Benchmark retrieval
-                let knowledge = strange_loop.get_knowledge_at_level(black_box(MetaLevel::base()));
-                black_box(knowledge)
-            });
-        });
+                b.iter(|| {
+                    // Benchmark retrieval
+                    let knowledge =
+                        strange_loop.get_knowledge_at_level(black_box(MetaLevel::base()));
+                    black_box(knowledge)
+                });
+            },
+        );
     }
 
     group.finish();
@@ -256,20 +286,24 @@ fn attractor_analysis_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("attractor_analysis");
 
     for trajectory_length in [10, 50, 100, 200].iter() {
-        group.bench_with_input(BenchmarkId::from_parameter(trajectory_length), trajectory_length, |b, &trajectory_length| {
-            let trajectory_data: Vec<Vec<f64>> = (0..trajectory_length)
-                .map(|i| {
-                    let t = i as f64 * 0.1;
-                    vec![t.sin(), t.cos(), (t * 2.0).sin()] // 3D trajectory
-                })
-                .collect();
+        group.bench_with_input(
+            BenchmarkId::from_parameter(trajectory_length),
+            trajectory_length,
+            |b, &trajectory_length| {
+                let trajectory_data: Vec<Vec<f64>> = (0..trajectory_length)
+                    .map(|i| {
+                        let t = i as f64 * 0.1;
+                        vec![t.sin(), t.cos(), (t * 2.0).sin()] // 3D trajectory
+                    })
+                    .collect();
 
-            b.iter(|| {
-                let mut strange_loop = StrangeLoop::default();
-                let result = strange_loop.analyze_behavior(black_box(trajectory_data.clone()));
-                black_box(result)
-            });
-        });
+                b.iter(|| {
+                    let mut strange_loop = StrangeLoop::default();
+                    let result = strange_loop.analyze_behavior(black_box(trajectory_data.clone()));
+                    black_box(result)
+                });
+            },
+        );
     }
 
     group.finish();
@@ -280,25 +314,29 @@ fn reset_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("reset_performance");
 
     for knowledge_size in [100, 500, 1000].iter() {
-        group.bench_with_input(BenchmarkId::from_parameter(knowledge_size), knowledge_size, |b, &knowledge_size| {
-            b.iter_batched(
-                || {
-                    // Setup: create strange loop with lots of knowledge
-                    let mut strange_loop = StrangeLoop::default();
-                    let data: Vec<String> = (0..knowledge_size)
-                        .map(|i| format!("pattern_{}", i % 20))
-                        .collect();
-                    let _ = strange_loop.learn_at_level(MetaLevel::base(), &data);
-                    strange_loop
-                },
-                |mut strange_loop| {
-                    // Benchmark reset
-                    strange_loop.reset();
-                    black_box(strange_loop)
-                },
-                criterion::BatchSize::SmallInput,
-            );
-        });
+        group.bench_with_input(
+            BenchmarkId::from_parameter(knowledge_size),
+            knowledge_size,
+            |b, &knowledge_size| {
+                b.iter_batched(
+                    || {
+                        // Setup: create strange loop with lots of knowledge
+                        let mut strange_loop = StrangeLoop::default();
+                        let data: Vec<String> = (0..knowledge_size)
+                            .map(|i| format!("pattern_{}", i % 20))
+                            .collect();
+                        let _ = strange_loop.learn_at_level(MetaLevel::base(), &data);
+                        strange_loop
+                    },
+                    |mut strange_loop| {
+                        // Benchmark reset
+                        strange_loop.reset();
+                        black_box(strange_loop)
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
     }
 
     group.finish();

--- a/crates/strange-loop/src/lib.rs
+++ b/crates/strange-loop/src/lib.rs
@@ -9,14 +9,14 @@
 //! - Tangled hierarchies
 //! - Meta-knowledge extraction
 
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use thiserror::Error;
 use dashmap::DashMap;
-use std::sync::Arc;
-use midstreamer_temporal_compare::TemporalComparator;
 use midstreamer_attractor::{AttractorAnalyzer, PhasePoint};
 use midstreamer_neural_solver::TemporalNeuralSolver;
+use midstreamer_temporal_compare::TemporalComparator;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+use thiserror::Error;
 
 /// Strange loop errors
 #[derive(Debug, Error)]
@@ -238,10 +238,7 @@ impl StrangeLoop {
         };
 
         // Extract meta-patterns
-        let meta_patterns: Vec<String> = knowledge
-            .iter()
-            .map(|k| k.pattern.clone())
-            .collect();
+        let meta_patterns: Vec<String> = knowledge.iter().map(|k| k.pattern.clone()).collect();
 
         // Learn at next level
         let next_level = level.next();
@@ -260,7 +257,7 @@ impl StrangeLoop {
 
         // Find recurring patterns using temporal comparison
         for i in 0..data.len() {
-            for j in i+1..data.len() {
+            for j in i + 1..data.len() {
                 if data[i] == data[j] {
                     // Found a repeating pattern
                     let pattern = MetaKnowledge::new(
@@ -280,19 +277,16 @@ impl StrangeLoop {
     }
 
     /// Apply self-modification with safety checks
-    pub fn apply_modification(
-        &mut self,
-        rule: ModificationRule,
-    ) -> Result<(), StrangeLoopError> {
+    pub fn apply_modification(&mut self, rule: ModificationRule) -> Result<(), StrangeLoopError> {
         if !self.config.enable_self_modification {
             return Err(StrangeLoopError::InvalidModification(
-                "Self-modification is disabled".to_string()
+                "Self-modification is disabled".to_string(),
             ));
         }
 
         if self.modification_count >= self.config.max_modifications_per_cycle {
             return Err(StrangeLoopError::InvalidModification(
-                "Max modifications per cycle reached".to_string()
+                "Max modifications per cycle reached".to_string(),
             ));
         }
 
@@ -348,7 +342,8 @@ impl StrangeLoop {
 
     /// Get summary statistics
     pub fn get_summary(&self) -> MetaLearningSummary {
-        let total_knowledge: usize = self.meta_knowledge
+        let total_knowledge: usize = self
+            .meta_knowledge
             .iter()
             .map(|entry| entry.value().len())
             .sum();
@@ -358,7 +353,8 @@ impl StrangeLoop {
             total_knowledge,
             total_modifications: self.modification_count,
             safety_violations: self.safety_violations,
-            learning_iterations: self.learning_iterations
+            learning_iterations: self
+                .learning_iterations
                 .iter()
                 .map(|entry| *entry.value())
                 .sum(),
@@ -375,14 +371,20 @@ impl StrangeLoop {
     }
 
     /// Analyze behavioral dynamics using attractor analysis
-    pub fn analyze_behavior(&mut self, trajectory_data: Vec<Vec<f64>>) -> Result<String, StrangeLoopError> {
+    pub fn analyze_behavior(
+        &mut self,
+        trajectory_data: Vec<Vec<f64>>,
+    ) -> Result<String, StrangeLoopError> {
         for (i, point_data) in trajectory_data.iter().enumerate() {
             let point = PhasePoint::new(point_data.clone(), i as u64);
-            self.attractor_analyzer.add_point(point)
+            self.attractor_analyzer
+                .add_point(point)
                 .map_err(|e| StrangeLoopError::MetaLearningFailed(e.to_string()))?;
         }
 
-        let analysis = self.attractor_analyzer.analyze()
+        let analysis = self
+            .attractor_analyzer
+            .analyze()
             .map_err(|e| StrangeLoopError::MetaLearningFailed(e.to_string()))?;
 
         Ok(format!("{:?}", analysis.attractor_type))

--- a/crates/strange-loop/tests/proptest_strange_loop.rs
+++ b/crates/strange-loop/tests/proptest_strange_loop.rs
@@ -28,9 +28,7 @@
 //!     * `learn_at_level` and `analyze_behavior` never panic on any
 //!       well-formed input.
 
-use midstreamer_strange_loop::{
-    MetaLevel, StrangeLoop, StrangeLoopConfig, StrangeLoopError,
-};
+use midstreamer_strange_loop::{MetaLevel, StrangeLoop, StrangeLoopConfig, StrangeLoopError};
 use proptest::prelude::*;
 
 fn fresh_loop(max_meta_depth: usize) -> StrangeLoop {

--- a/crates/temporal-attractor-studio/src/lib.rs
+++ b/crates/temporal-attractor-studio/src/lib.rs
@@ -48,7 +48,10 @@ pub struct PhasePoint {
 
 impl PhasePoint {
     pub fn new(coordinates: Vec<f64>, timestamp: u64) -> Self {
-        Self { coordinates, timestamp }
+        Self {
+            coordinates,
+            timestamp,
+        }
     }
 
     pub fn dimension(&self) -> usize {
@@ -107,9 +110,10 @@ impl AttractorInfo {
     }
 
     pub fn max_lyapunov_exponent(&self) -> Option<f64> {
-        self.lyapunov_exponents.iter().copied().max_by(|a, b| {
-            a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)
-        })
+        self.lyapunov_exponents
+            .iter()
+            .copied()
+            .max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
     }
 }
 
@@ -153,7 +157,9 @@ impl AttractorAnalyzer {
     /// Analyze the current trajectory
     pub fn analyze(&self) -> Result<AttractorInfo, AttractorError> {
         if self.trajectory.len() < self.min_points_for_analysis {
-            return Err(AttractorError::InsufficientData(self.min_points_for_analysis));
+            return Err(AttractorError::InsufficientData(
+                self.min_points_for_analysis,
+            ));
         }
 
         // Calculate Lyapunov exponents
@@ -198,7 +204,7 @@ impl AttractorAnalyzer {
             let mut count = 0;
 
             for i in 1..points.len() {
-                let diff = points[i].coordinates[dim] - points[i-1].coordinates[dim];
+                let diff = points[i].coordinates[dim] - points[i - 1].coordinates[dim];
                 if diff.abs() > 1e-10 {
                     sum_log_divergence += diff.abs().ln();
                     count += 1;
@@ -215,7 +221,8 @@ impl AttractorAnalyzer {
 
     /// Classify attractor based on Lyapunov exponents
     fn classify_attractor(&self, lyapunov_exponents: &[f64]) -> AttractorType {
-        let max_exponent = lyapunov_exponents.iter()
+        let max_exponent = lyapunov_exponents
+            .iter()
             .copied()
             .max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
             .unwrap_or(0.0);
@@ -245,13 +252,14 @@ impl AttractorAnalyzer {
         let n = points.len();
 
         // Check for repeating patterns
-        for lag in 5..n/4 {
+        for lag in 5..n / 4 {
             let mut correlation = 0.0;
             let mut count = 0;
 
-            for i in 0..n-lag {
+            for i in 0..n - lag {
                 for dim in 0..self.embedding_dimension {
-                    let diff = (points[i].coordinates[dim] - points[i+lag].coordinates[dim]).abs();
+                    let diff =
+                        (points[i].coordinates[dim] - points[i + lag].coordinates[dim]).abs();
                     correlation += diff;
                     count += 1;
                 }
@@ -284,13 +292,13 @@ impl AttractorAnalyzer {
         for i in 1..points.len() {
             let mut distance = 0.0;
             for dim in 0..self.embedding_dimension {
-                let diff = points[i].coordinates[dim] - points[i-1].coordinates[dim];
+                let diff = points[i].coordinates[dim] - points[i - 1].coordinates[dim];
                 distance += diff * diff;
             }
             let segment_length = distance.sqrt();
             trajectory_length += segment_length;
 
-            let time_diff = (points[i].timestamp - points[i-1].timestamp) as f64;
+            let time_diff = (points[i].timestamp - points[i - 1].timestamp) as f64;
             if time_diff > 0.0 {
                 velocity_sum += segment_length / time_diff;
             }
@@ -367,10 +375,7 @@ mod tests {
 
         // Add some points
         for i in 0..150 {
-            let point = PhasePoint::new(
-                vec![i as f64, (i * 2) as f64],
-                i as u64 * 1000,
-            );
+            let point = PhasePoint::new(vec![i as f64, (i * 2) as f64], i as u64 * 1000);
             analyzer.add_point(point).unwrap();
         }
 
@@ -408,10 +413,7 @@ mod tests {
         let mut analyzer = AttractorAnalyzer::new(2, 1000);
 
         for i in 0..50 {
-            let point = PhasePoint::new(
-                vec![i as f64, i as f64],
-                i as u64 * 100,
-            );
+            let point = PhasePoint::new(vec![i as f64, i as f64], i as u64 * 100);
             analyzer.add_point(point).unwrap();
         }
 

--- a/crates/temporal-attractor-studio/tests/proptest_attractor.rs
+++ b/crates/temporal-attractor-studio/tests/proptest_attractor.rs
@@ -22,16 +22,13 @@
 //!   * Constant trajectory (same point repeated) is never classified as
 //!     chaotic — a degenerate trajectory cannot be a strange attractor.
 
-use midstreamer_attractor::{
-    AttractorAnalyzer, AttractorType, PhasePoint,
-};
+use midstreamer_attractor::{AttractorAnalyzer, AttractorType, PhasePoint};
 use proptest::prelude::*;
 
 /// Bounded f64 generator: excludes NaN, Inf, subnormals, and values
 /// large enough to overflow Lyapunov accumulators.
 fn bounded_coord() -> impl Strategy<Value = f64> {
-    (-10.0_f64..10.0)
-        .prop_filter("finite", |v| v.is_finite() && !v.is_subnormal())
+    (-10.0_f64..10.0).prop_filter("finite", |v| v.is_finite() && !v.is_subnormal())
 }
 
 /// Generator for a phase-space trajectory: 50..=200 points of

--- a/crates/temporal-compare/src/lib.rs
+++ b/crates/temporal-compare/src/lib.rs
@@ -9,15 +9,15 @@
 //! - Pattern matching and detection
 //! - Efficient caching
 
+use dashmap::DashMap;
+use lru::LruCache;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
 use std::hash::Hash;
-use thiserror::Error;
-use dashmap::DashMap;
-use lru::LruCache;
-use std::sync::{Arc, Mutex};
 use std::num::NonZeroUsize;
+use std::sync::{Arc, Mutex};
+use thiserror::Error;
 
 /// Errors that can occur during temporal comparison
 #[derive(Debug, Error)]
@@ -53,7 +53,9 @@ pub struct Sequence<T> {
 
 impl<T> Sequence<T> {
     pub fn new() -> Self {
-        Self { elements: Vec::new() }
+        Self {
+            elements: Vec::new(),
+        }
     }
 
     pub fn push(&mut self, value: T, timestamp: u64) {
@@ -188,13 +190,13 @@ where
     pub fn new(cache_size: usize, max_sequence_length: usize) -> Self {
         Self {
             cache: Arc::new(Mutex::new(LruCache::new(
-                NonZeroUsize::new(cache_size).unwrap()
+                NonZeroUsize::new(cache_size).unwrap(),
             ))),
             pattern_cache: Arc::new(Mutex::new(LruCache::new(
-                NonZeroUsize::new(cache_size).unwrap()
+                NonZeroUsize::new(cache_size).unwrap(),
             ))),
             similarity_cache: Arc::new(Mutex::new(LruCache::new(
-                NonZeroUsize::new(cache_size).unwrap()
+                NonZeroUsize::new(cache_size).unwrap(),
             ))),
             cache_hits: Arc::new(DashMap::new()),
             cache_misses: Arc::new(DashMap::new()),
@@ -211,9 +213,7 @@ where
     ) -> Result<ComparisonResult, TemporalError> {
         // Check sequence length
         if seq1.len() > self.max_sequence_length || seq2.len() > self.max_sequence_length {
-            return Err(TemporalError::SequenceTooLong(
-                seq1.len().max(seq2.len())
-            ));
+            return Err(TemporalError::SequenceTooLong(seq1.len().max(seq2.len())));
         }
 
         // Generate cache key
@@ -246,7 +246,11 @@ where
     }
 
     /// Dynamic Time Warping implementation
-    fn dtw(&self, seq1: &Sequence<T>, seq2: &Sequence<T>) -> Result<ComparisonResult, TemporalError> {
+    fn dtw(
+        &self,
+        seq1: &Sequence<T>,
+        seq2: &Sequence<T>,
+    ) -> Result<ComparisonResult, TemporalError> {
         let n = seq1.len();
         let m = seq2.len();
 
@@ -265,13 +269,13 @@ where
         // Fill DTW matrix
         for i in 1..=n {
             for j in 1..=m {
-                let cost = if seq1.elements[i-1].value == seq2.elements[j-1].value {
+                let cost = if seq1.elements[i - 1].value == seq2.elements[j - 1].value {
                     0.0
                 } else {
                     1.0
                 };
 
-                dtw[i][j] = cost + dtw[i-1][j-1].min(dtw[i-1][j]).min(dtw[i][j-1]);
+                dtw[i][j] = cost + dtw[i - 1][j - 1].min(dtw[i - 1][j]).min(dtw[i][j - 1]);
             }
         }
 
@@ -282,12 +286,12 @@ where
         while i > 0 && j > 0 {
             alignment.push((i - 1, j - 1));
 
-            let min_val = dtw[i-1][j-1].min(dtw[i-1][j]).min(dtw[i][j-1]);
+            let min_val = dtw[i - 1][j - 1].min(dtw[i - 1][j]).min(dtw[i][j - 1]);
 
-            if dtw[i-1][j-1] == min_val {
+            if dtw[i - 1][j - 1] == min_val {
                 i -= 1;
                 j -= 1;
-            } else if dtw[i-1][j] == min_val {
+            } else if dtw[i - 1][j] == min_val {
                 i -= 1;
             } else {
                 j -= 1;
@@ -304,7 +308,11 @@ where
     }
 
     /// Longest Common Subsequence implementation
-    fn lcs(&self, seq1: &Sequence<T>, seq2: &Sequence<T>) -> Result<ComparisonResult, TemporalError> {
+    fn lcs(
+        &self,
+        seq1: &Sequence<T>,
+        seq2: &Sequence<T>,
+    ) -> Result<ComparisonResult, TemporalError> {
         let n = seq1.len();
         let m = seq2.len();
 
@@ -312,10 +320,10 @@ where
 
         for i in 1..=n {
             for j in 1..=m {
-                if seq1.elements[i-1].value == seq2.elements[j-1].value {
-                    dp[i][j] = dp[i-1][j-1] + 1;
+                if seq1.elements[i - 1].value == seq2.elements[j - 1].value {
+                    dp[i][j] = dp[i - 1][j - 1] + 1;
                 } else {
-                    dp[i][j] = dp[i-1][j].max(dp[i][j-1]);
+                    dp[i][j] = dp[i - 1][j].max(dp[i][j - 1]);
                 }
             }
         }
@@ -331,7 +339,11 @@ where
     }
 
     /// Edit Distance (Levenshtein) implementation
-    fn edit_distance(&self, seq1: &Sequence<T>, seq2: &Sequence<T>) -> Result<ComparisonResult, TemporalError> {
+    fn edit_distance(
+        &self,
+        seq1: &Sequence<T>,
+        seq2: &Sequence<T>,
+    ) -> Result<ComparisonResult, TemporalError> {
         let n = seq1.len();
         let m = seq2.len();
 
@@ -351,15 +363,15 @@ where
 
         for i in 1..=n {
             for j in 1..=m {
-                let cost = if seq1.elements[i-1].value == seq2.elements[j-1].value {
+                let cost = if seq1.elements[i - 1].value == seq2.elements[j - 1].value {
                     0
                 } else {
                     1
                 };
 
-                dp[i][j] = (dp[i-1][j] + 1)
-                    .min(dp[i][j-1] + 1)
-                    .min(dp[i-1][j-1] + cost);
+                dp[i][j] = (dp[i - 1][j] + 1)
+                    .min(dp[i][j - 1] + 1)
+                    .min(dp[i - 1][j - 1] + cost);
             }
         }
 
@@ -371,7 +383,11 @@ where
     }
 
     /// Euclidean distance (for numeric sequences)
-    fn euclidean(&self, seq1: &Sequence<T>, seq2: &Sequence<T>) -> Result<ComparisonResult, TemporalError> {
+    fn euclidean(
+        &self,
+        seq1: &Sequence<T>,
+        seq2: &Sequence<T>,
+    ) -> Result<ComparisonResult, TemporalError> {
         let n = seq1.len().min(seq2.len());
         let mut sum: f64 = 0.0;
 
@@ -390,7 +406,12 @@ where
     }
 
     /// Generate cache key for a comparison
-    fn cache_key(&self, seq1: &Sequence<T>, seq2: &Sequence<T>, algorithm: ComparisonAlgorithm) -> String {
+    fn cache_key(
+        &self,
+        seq1: &Sequence<T>,
+        seq2: &Sequence<T>,
+        algorithm: ComparisonAlgorithm,
+    ) -> String {
         format!(
             "{:?}:{:?}:{:?}",
             seq1.elements.len(),
@@ -400,13 +421,15 @@ where
     }
 
     fn record_cache_hit(&self, key: &str) {
-        self.cache_hits.entry(key.to_string())
+        self.cache_hits
+            .entry(key.to_string())
             .and_modify(|v| *v += 1)
             .or_insert(1);
     }
 
     fn record_cache_miss(&self, key: &str) {
-        self.cache_misses.entry(key.to_string())
+        self.cache_misses
+            .entry(key.to_string())
             .and_modify(|v| *v += 1)
             .or_insert(1);
     }
@@ -558,10 +581,7 @@ where
             for start_idx in 0..=(sequence.len() - pattern_len) {
                 let pattern_seq = sequence[start_idx..start_idx + pattern_len].to_vec();
 
-                pattern_map
-                    .entry(pattern_seq)
-                    .or_default()
-                    .push(start_idx);
+                pattern_map.entry(pattern_seq).or_default().push(start_idx);
             }
         }
 
@@ -576,8 +596,8 @@ where
                 let total_possible = (sequence.len() - seq.len() + 1) as f64;
 
                 // Confidence is weighted by frequency and pattern length
-                let confidence = ((frequency / total_possible) * (pattern_len / max_length as f64))
-                    .min(1.0);
+                let confidence =
+                    ((frequency / total_possible) * (pattern_len / max_length as f64)).min(1.0);
 
                 Pattern::new(seq, occurrences, confidence)
             })
@@ -585,13 +605,11 @@ where
 
         // Sort by frequency (most common first), then by confidence
         patterns.sort_by(|a, b| {
-            b.frequency()
-                .cmp(&a.frequency())
-                .then_with(|| {
-                    b.confidence
-                        .partial_cmp(&a.confidence)
-                        .unwrap_or(std::cmp::Ordering::Equal)
-                })
+            b.frequency().cmp(&a.frequency()).then_with(|| {
+                b.confidence
+                    .partial_cmp(&a.confidence)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
         });
 
         // Store in cache
@@ -640,7 +658,9 @@ mod tests {
         seq2.push(2, 200);
         seq2.push(3, 300);
 
-        let result = comparator.compare(&seq1, &seq2, ComparisonAlgorithm::DTW).unwrap();
+        let result = comparator
+            .compare(&seq1, &seq2, ComparisonAlgorithm::DTW)
+            .unwrap();
         assert_eq!(result.distance, 0.0);
     }
 
@@ -657,10 +677,14 @@ mod tests {
         seq2.push(2, 2);
 
         // First comparison - cache miss
-        comparator.compare(&seq1, &seq2, ComparisonAlgorithm::DTW).unwrap();
+        comparator
+            .compare(&seq1, &seq2, ComparisonAlgorithm::DTW)
+            .unwrap();
 
         // Second comparison - cache hit
-        comparator.compare(&seq1, &seq2, ComparisonAlgorithm::DTW).unwrap();
+        comparator
+            .compare(&seq1, &seq2, ComparisonAlgorithm::DTW)
+            .unwrap();
 
         let stats = comparator.cache_stats();
         assert_eq!(stats.hits, 1);
@@ -674,7 +698,9 @@ mod tests {
         let haystack = vec![1, 2, 3, 4, 5, 3, 4, 5];
         let needle = vec![3, 4, 5];
 
-        let matches = comparator.find_similar_generic(&haystack, &needle, 0.1).unwrap();
+        let matches = comparator
+            .find_similar_generic(&haystack, &needle, 0.1)
+            .unwrap();
 
         assert_eq!(matches.len(), 2);
         assert_eq!(matches[0].start_index, 2);
@@ -688,7 +714,9 @@ mod tests {
 
         let sequence = vec!['a', 'b', 'c', 'a', 'b', 'c', 'a', 'b', 'c'];
 
-        let patterns = comparator.detect_recurring_patterns(&sequence, 2, 4).unwrap();
+        let patterns = comparator
+            .detect_recurring_patterns(&sequence, 2, 4)
+            .unwrap();
 
         assert!(!patterns.is_empty());
         // Should find 'abc' pattern recurring

--- a/crates/temporal-compare/tests/proptest_metrics.rs
+++ b/crates/temporal-compare/tests/proptest_metrics.rs
@@ -30,9 +30,7 @@
 //! LCS / DTW algorithms compare values only via `==`, so the choice
 //! of integer-vs-float values does not change which code paths run.
 
-use midstreamer_temporal_compare::{
-    ComparisonAlgorithm, Sequence, TemporalComparator,
-};
+use midstreamer_temporal_compare::{ComparisonAlgorithm, Sequence, TemporalComparator};
 use proptest::prelude::*;
 
 /// Build a `Sequence<i32>` from a Vec by assigning evenly-spaced

--- a/crates/temporal-neural-solver/src/lib.rs
+++ b/crates/temporal-neural-solver/src/lib.rs
@@ -271,7 +271,11 @@ impl TemporalNeuralSolver {
     }
 
     /// Check if formula holds at given position in trace
-    fn check_formula(&self, formula: &TemporalFormula, position: usize) -> Result<bool, TemporalError> {
+    fn check_formula(
+        &self,
+        formula: &TemporalFormula,
+        position: usize,
+    ) -> Result<bool, TemporalError> {
         match formula {
             TemporalFormula::True => Ok(true),
             TemporalFormula::False => Ok(false),
@@ -286,9 +290,7 @@ impl TemporalNeuralSolver {
 
             TemporalFormula::Unary { op, formula } => {
                 match op {
-                    TemporalOperator::Not => {
-                        Ok(!self.check_formula(formula, position)?)
-                    }
+                    TemporalOperator::Not => Ok(!self.check_formula(formula, position)?),
                     TemporalOperator::Next => {
                         if position + 1 < self.trace.len() {
                             self.check_formula(formula, position + 1)
@@ -314,21 +316,21 @@ impl TemporalNeuralSolver {
                         }
                         Ok(false)
                     }
-                    _ => Err(TemporalError::ParseError(format!("Invalid unary operator: {:?}", op))),
+                    _ => Err(TemporalError::ParseError(format!(
+                        "Invalid unary operator: {:?}",
+                        op
+                    ))),
                 }
             }
 
             TemporalFormula::Binary { op, left, right } => {
                 match op {
-                    TemporalOperator::And => {
-                        Ok(self.check_formula(left, position)? && self.check_formula(right, position)?)
-                    }
-                    TemporalOperator::Or => {
-                        Ok(self.check_formula(left, position)? || self.check_formula(right, position)?)
-                    }
-                    TemporalOperator::Implies => {
-                        Ok(!self.check_formula(left, position)? || self.check_formula(right, position)?)
-                    }
+                    TemporalOperator::And => Ok(self.check_formula(left, position)?
+                        && self.check_formula(right, position)?),
+                    TemporalOperator::Or => Ok(self.check_formula(left, position)?
+                        || self.check_formula(right, position)?),
+                    TemporalOperator::Implies => Ok(!self.check_formula(left, position)?
+                        || self.check_formula(right, position)?),
                     TemporalOperator::Until => {
                         // φ U ψ: φ holds until ψ becomes true
                         for i in position..self.trace.len() {
@@ -344,7 +346,10 @@ impl TemporalNeuralSolver {
                         }
                         Ok(false)
                     }
-                    _ => Err(TemporalError::ParseError(format!("Invalid binary operator: {:?}", op))),
+                    _ => Err(TemporalError::ParseError(format!(
+                        "Invalid binary operator: {:?}",
+                        op
+                    ))),
                 }
             }
         }
@@ -364,7 +369,10 @@ impl TemporalNeuralSolver {
     }
 
     /// Synthesize a controller to satisfy a formula
-    pub fn synthesize_controller(&self, _formula: &TemporalFormula) -> Result<Vec<String>, TemporalError> {
+    pub fn synthesize_controller(
+        &self,
+        _formula: &TemporalFormula,
+    ) -> Result<Vec<String>, TemporalError> {
         // Simplified controller synthesis
         // In production, this would use more sophisticated techniques
         Ok(vec!["action1".to_string(), "action2".to_string()])

--- a/crates/temporal-neural-solver/tests/proptest_ltl.rs
+++ b/crates/temporal-neural-solver/tests/proptest_ltl.rs
@@ -98,10 +98,7 @@ fn formula_strategy() -> impl Strategy<Value = TemporalFormula> {
 
 const PROPS: &[&str] = &["p", "q", "r"];
 
-fn verify_satisfied(
-    solver: &TemporalNeuralSolver,
-    formula: &TemporalFormula,
-) -> bool {
+fn verify_satisfied(solver: &TemporalNeuralSolver, formula: &TemporalFormula) -> bool {
     solver.verify(formula).map(|r| r.satisfied).unwrap_or(false)
 }
 

--- a/examples/lean_agentic_streaming.rs
+++ b/examples/lean_agentic_streaming.rs
@@ -9,12 +9,12 @@
 //!
 //! Run with: cargo run --example lean_agentic_streaming
 
-use midstream::{
-    LeanAgenticSystem, LeanAgenticConfig, AgentContext,
-    Midstream, HyprSettings, HyprServiceImpl, StreamProcessor, LLMClient,
-};
 use bytes::Bytes;
-use futures::stream::{BoxStream, iter};
+use futures::stream::{iter, BoxStream};
+use midstream::{
+    AgentContext, HyprServiceImpl, HyprSettings, LLMClient, LeanAgenticConfig, LeanAgenticSystem,
+    Midstream, StreamProcessor,
+};
 use tokio;
 
 /// Example LLM client that simulates streaming responses
@@ -66,10 +66,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let hypr_service = HyprServiceImpl::new(&settings).await?;
     let llm_client = SimulatedLLMClient::new();
 
-    let midstream = Midstream::new(
-        Box::new(llm_client),
-        Box::new(hypr_service),
-    );
+    let midstream = Midstream::new(Box::new(llm_client), Box::new(hypr_service));
     println!("✓ MidStream ready\n");
 
     // 3. Process stream with lean agentic learning
@@ -88,14 +85,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("  Message #{}: {}", i + 1, chunk);
 
         // Process with lean agentic system
-        let result = lean_system.process_stream_chunk(
-            &chunk,
-            context.clone(),
-        ).await?;
+        let result = lean_system
+            .process_stream_chunk(&chunk, context.clone())
+            .await?;
 
         println!("    → Action: {}", result.action.description);
         println!("    → Reward: {:.2}", result.reward);
-        println!("    → Verified: {}", if result.verified { "✓" } else { "✗" });
+        println!(
+            "    → Verified: {}",
+            if result.verified { "✓" } else { "✗" }
+        );
 
         // Update context
         context.add_message(chunk.into_owned());
@@ -139,7 +138,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\n  3. Online Learning:");
     let learner = lean_system.learner.read().await;
     let learning_stats = learner.get_stats();
-    println!("     - Model parameters: {}", learning_stats.model_parameters);
+    println!(
+        "     - Model parameters: {}",
+        learning_stats.model_parameters
+    );
     println!("     - Experience buffer: {}", learning_stats.buffer_size);
     drop(learner);
 

--- a/examples/openrouter.rs
+++ b/examples/openrouter.rs
@@ -1,11 +1,11 @@
-use midstream::{Midstream, HyprSettings, HyprServiceImpl, StreamProcessor, LLMClient};
 use bytes::Bytes;
+use dotenvy::dotenv;
+use eventsource_stream::Eventsource;
 use futures::stream::{BoxStream, StreamExt};
+use midstream::{HyprServiceImpl, HyprSettings, LLMClient, Midstream, StreamProcessor};
 use reqwest::Client;
 use serde_json::{json, Value};
 use std::time::Duration;
-use eventsource_stream::Eventsource;
-use dotenvy::dotenv;
 
 struct OpenRouterClient {
     client: Client,
@@ -26,15 +26,15 @@ impl LLMClient for OpenRouterClient {
         let prompt = "Tell me a short story about a robot learning to paint. Make it emotional and stream it word by word.".to_string();
         let client = self.client.clone();
         let api_key = self.api_key.clone();
-        
+
         Box::pin(async_stream::stream! {
             let url = "https://openrouter.ai/api/v1/chat/completions";
             let referer = std::env::var("OPENROUTER_REFERER").unwrap_or_else(|_| "http://localhost:3000".to_string());
             let model = std::env::var("OPENROUTER_MODEL").unwrap_or_else(|_| "anthropic/claude-2".to_string());
-            
+
             println!("Sending request to OpenRouter API...");
             println!("Model: {}", model);
-            
+
             let payload = json!({
                 "model": model,
                 "messages": [
@@ -56,7 +56,7 @@ impl LLMClient for OpenRouterClient {
                 .expect("Failed to send request");
 
             println!("Response status: {}", response.status());
-            
+
             let mut stream = response
                 .bytes_stream()
                 .eventsource()
@@ -107,37 +107,34 @@ impl LLMClient for OpenRouterClient {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Load environment variables
     dotenv().ok();
-    
+
     // Get API key from environment
-    let api_key = std::env::var("OPENROUTER_API_KEY")
-        .expect("OPENROUTER_API_KEY must be set in .env file");
+    let api_key =
+        std::env::var("OPENROUTER_API_KEY").expect("OPENROUTER_API_KEY must be set in .env file");
 
     // Initialize settings
     let settings = HyprSettings::new()?;
-    
+
     // Create hyprstream service
     let hypr_service = HyprServiceImpl::new(&settings).await?;
-    
+
     // Create OpenRouter client
     let llm_client = OpenRouterClient::new(api_key);
-    
+
     // Initialize Midstream
-    let midstream = Midstream::new(
-        Box::new(llm_client),
-        Box::new(hypr_service),
-    );
-    
+    let midstream = Midstream::new(Box::new(llm_client), Box::new(hypr_service));
+
     println!("\nStreaming story from Claude-2...\n");
 
     // Process stream
     let messages = midstream.process_stream().await?;
-    
+
     println!("\nFinal story:");
     for msg in &messages {
         print!("{}", msg.content_str());
     }
     println!("\n");
-    
+
     // Get metrics
     let metrics = midstream.get_metrics().await;
     println!("\nMetrics collected:");
@@ -146,10 +143,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("  Labels: {:?}", metric.labels);
         println!();
     }
-    
+
     // Get average sentiment for last 5 minutes
-    let avg = midstream.get_average_sentiment(Duration::from_secs(300)).await?;
+    let avg = midstream
+        .get_average_sentiment(Duration::from_secs(300))
+        .await?;
     println!("\nAverage tokens per message: {:.2}", avg);
-    
+
     Ok(())
 }

--- a/examples/pattern_detection_demo.rs
+++ b/examples/pattern_detection_demo.rs
@@ -4,8 +4,7 @@
 /// 1. find_similar() - Find similar patterns in time series
 /// 2. detect_pattern() - Detect if a pattern exists
 /// 3. Advanced APIs for recurring and fuzzy pattern detection
-
-use midstreamer_temporal_compare::{TemporalComparator, Pattern};
+use midstreamer_temporal_compare::{Pattern, TemporalComparator};
 
 fn main() {
     println!("=== Temporal-Compare Pattern Detection Demo ===\n");
@@ -78,11 +77,15 @@ fn main() {
     println!("Haystack: {:?}", haystack);
     println!("Needle: {:?}", needle);
 
-    let matches = comparator_int.find_similar_generic(&haystack, &needle, 0.1).unwrap();
+    let matches = comparator_int
+        .find_similar_generic(&haystack, &needle, 0.1)
+        .unwrap();
     println!("Found {} matches:", matches.len());
     for m in &matches {
-        println!("  - Index {}: similarity = {:.4}, distance = {:.4}",
-                 m.start_index, m.similarity, m.distance);
+        println!(
+            "  - Index {}: similarity = {:.4}, distance = {:.4}",
+            m.start_index, m.similarity, m.distance
+        );
     }
     println!();
 
@@ -95,7 +98,9 @@ fn main() {
 
     println!("Sequence: {:?}", sequence);
 
-    let patterns = comparator_char.detect_recurring_patterns(&sequence, 2, 3).unwrap();
+    let patterns = comparator_char
+        .detect_recurring_patterns(&sequence, 2, 3)
+        .unwrap();
     println!("Found {} recurring patterns:", patterns.len());
     for (i, pattern) in patterns.iter().enumerate() {
         println!("  Pattern {}: {:?}", i + 1, pattern.sequence);
@@ -114,11 +119,16 @@ fn main() {
 
     println!("Sequence: {:?}", sequence);
 
-    let fuzzy_patterns = comparator_fuzzy.detect_fuzzy_patterns(&sequence, 3, 3, 0.7).unwrap();
+    let fuzzy_patterns = comparator_fuzzy
+        .detect_fuzzy_patterns(&sequence, 3, 3, 0.7)
+        .unwrap();
     println!("Found {} fuzzy pattern groups:", fuzzy_patterns.len());
     for (i, pattern) in fuzzy_patterns.iter().enumerate() {
         println!("  Pattern Group {}: {:?}", i + 1, pattern.sequence);
-        println!("    Frequency: {} (includes variations)", pattern.frequency());
+        println!(
+            "    Frequency: {} (includes variations)",
+            pattern.frequency()
+        );
         println!("    Confidence: {:.4}", pattern.confidence);
     }
     println!();
@@ -134,8 +144,13 @@ fn main() {
     for i in 1..=5 {
         let _ = comparator.find_similar(&series1, &pattern1, 0.5);
         let stats = comparator.cache_stats();
-        println!("  Iteration {}: hits = {}, misses = {}, hit rate = {:.2}%",
-                 i, stats.hits, stats.misses, stats.hit_rate() * 100.0);
+        println!(
+            "  Iteration {}: hits = {}, misses = {}, hit rate = {:.2}%",
+            i,
+            stats.hits,
+            stats.misses,
+            stats.hit_rate() * 100.0
+        );
     }
     println!();
 

--- a/examples/quic_server.rs
+++ b/examples/quic_server.rs
@@ -23,13 +23,13 @@
 //! curl --http3 https://localhost:4433 --insecure
 //! ```
 
-use midstream_quic::{QuicMultiStream, QuicConfig, StreamPriority};
-use std::sync::Arc;
+use midstream_quic::{QuicConfig, QuicMultiStream, StreamPriority};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::signal;
 use tokio::time::{Duration, Instant};
-use tracing::{info, warn, error, debug};
+use tracing::{debug, error, info, warn};
 
 /// Server configuration constants
 const SERVER_PORT: u16 = 4433;
@@ -100,13 +100,17 @@ async fn handle_stream(
         match recv.read(&mut buffer).await? {
             Some(bytes_read) => {
                 total_bytes += bytes_read as u64;
-                stats.bytes_received.fetch_add(bytes_read as u64, Ordering::Relaxed);
+                stats
+                    .bytes_received
+                    .fetch_add(bytes_read as u64, Ordering::Relaxed);
 
                 debug!("Stream {} received {} bytes", stream_id, bytes_read);
 
                 // Echo back the data
                 stream.write_all(&buffer[..bytes_read]).await?;
-                stats.bytes_sent.fetch_add(bytes_read as u64, Ordering::Relaxed);
+                stats
+                    .bytes_sent
+                    .fetch_add(bytes_read as u64, Ordering::Relaxed);
 
                 // Check for special commands
                 if let Ok(msg) = std::str::from_utf8(&buffer[..bytes_read]) {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,7 +1,7 @@
-use midstream::{Midstream, HyprSettings, HyprServiceImpl, StreamProcessor, LLMClient};
 use bytes::Bytes;
-use futures::stream::BoxStream;
 use futures::stream::iter;
+use futures::stream::BoxStream;
+use midstream::{HyprServiceImpl, HyprSettings, LLMClient, Midstream, StreamProcessor};
 use std::time::Duration;
 
 // Example LLM client implementation
@@ -21,19 +21,16 @@ impl LLMClient for ExampleLLMClient {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize settings
     let settings = HyprSettings::new()?;
-    
+
     // Create hyprstream service
     let hypr_service = HyprServiceImpl::new(&settings).await?;
-    
+
     // Create LLM client
     let llm_client = ExampleLLMClient;
-    
+
     // Initialize Midstream
-    let midstream = Midstream::new(
-        Box::new(llm_client),
-        Box::new(hypr_service),
-    );
-    
+    let midstream = Midstream::new(Box::new(llm_client), Box::new(hypr_service));
+
     // Process stream
     let messages = midstream.process_stream().await?;
     println!("\nProcessed messages:");
@@ -45,7 +42,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         println!();
     }
-    
+
     // Get metrics
     let metrics = midstream.get_metrics().await;
     println!("\nCollected metrics:");
@@ -55,10 +52,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("  Labels: {:?}", metric.labels);
         println!();
     }
-    
+
     // Get average sentiment for last 5 minutes
-    let avg = midstream.get_average_sentiment(Duration::from_secs(300)).await?;
+    let avg = midstream
+        .get_average_sentiment(Duration::from_secs(300))
+        .await?;
     println!("\nAverage sentiment: {}", avg);
-    
+
     Ok(())
 }

--- a/src/lean_agentic/attractor.rs
+++ b/src/lean_agentic/attractor.rs
@@ -52,11 +52,7 @@ pub struct Trajectory {
 
 impl Trajectory {
     /// Create a new trajectory with time-delay embedding
-    pub fn from_timeseries(
-        data: &[f64],
-        embedding_dim: usize,
-        time_delay: usize,
-    ) -> Self {
+    pub fn from_timeseries(data: &[f64], embedding_dim: usize, time_delay: usize) -> Self {
         let mut points = Vec::new();
 
         // Time-delay embedding (Takens' theorem)
@@ -124,11 +120,8 @@ impl AttractorAnalyzer {
         }
 
         // Reconstruct phase space
-        let trajectory = Trajectory::from_timeseries(
-            data,
-            self.embedding_dimension,
-            self.time_delay,
-        );
+        let trajectory =
+            Trajectory::from_timeseries(data, self.embedding_dimension, self.time_delay);
 
         // Calculate Lyapunov exponent
         let lyapunov = self.calculate_lyapunov_exponent(&trajectory);
@@ -429,9 +422,7 @@ mod tests {
         let analyzer = AttractorAnalyzer::new(2, 1);
 
         // Sine wave => limit cycle
-        let data: Vec<f64> = (0..100)
-            .map(|i| (i as f64 * 0.1).sin())
-            .collect();
+        let data: Vec<f64> = (0..100).map(|i| (i as f64 * 0.1).sin()).collect();
 
         let info = analyzer.analyze(&data).unwrap();
 

--- a/src/lean_agentic/knowledge.rs
+++ b/src/lean_agentic/knowledge.rs
@@ -1,8 +1,8 @@
 //! Knowledge graph and theorem store for dynamic knowledge representation
 
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
-use async_trait::async_trait;
 
 use super::reasoning::Theorem;
 
@@ -44,7 +44,12 @@ impl KnowledgeGraph {
 
         for (i, word) in words.iter().enumerate() {
             // Capitalize words might be entities
-            if word.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+            if word
+                .chars()
+                .next()
+                .map(|c| c.is_uppercase())
+                .unwrap_or(false)
+            {
                 entities.push(Entity {
                     id: format!("entity_{}", i),
                     name: word.to_string(),
@@ -102,7 +107,8 @@ impl KnowledgeGraph {
 
     /// Query entities by type
     pub fn query_entities(&self, entity_type: EntityType) -> Vec<&Entity> {
-        self.entities.values()
+        self.entities
+            .values()
             .filter(|e| e.entity_type == entity_type)
             .collect()
     }
@@ -149,25 +155,21 @@ impl KnowledgeGraph {
 
     /// Get facts valid at a specific time
     pub fn get_facts_at_time(&self, timestamp: i64) -> Vec<&TemporalFact> {
-        self.temporal_facts.iter()
+        self.temporal_facts
+            .iter()
             .filter(|f| {
-                f.valid_from <= timestamp &&
-                f.valid_until.map(|t| timestamp <= t).unwrap_or(true)
+                f.valid_from <= timestamp && f.valid_until.map(|t| timestamp <= t).unwrap_or(true)
             })
             .collect()
     }
 
     /// Compute semantic similarity between entities
     pub fn compute_similarity(&self, entity1: &str, entity2: &str) -> f64 {
-        if let (Some(emb1), Some(emb2)) = (
-            self.embeddings.get(entity1),
-            self.embeddings.get(entity2)
-        ) {
+        if let (Some(emb1), Some(emb2)) =
+            (self.embeddings.get(entity1), self.embeddings.get(entity2))
+        {
             // Cosine similarity
-            let dot_product: f64 = emb1.iter()
-                .zip(emb2.iter())
-                .map(|(a, b)| a * b)
-                .sum();
+            let dot_product: f64 = emb1.iter().zip(emb2.iter()).map(|(a, b)| a * b).sum();
 
             let norm1: f64 = emb1.iter().map(|x| x * x).sum::<f64>().sqrt();
             let norm2: f64 = emb2.iter().map(|x| x * x).sum::<f64>().sqrt();

--- a/src/lean_agentic/mod.rs
+++ b/src/lean_agentic/mod.rs
@@ -31,46 +31,42 @@
 //! └─────────────────────────────────────────────────────────┘
 //! ```
 
-pub mod reasoning;
 pub mod agent;
+pub mod attractor;
 pub mod knowledge;
 pub mod learning;
-pub mod types;
 pub mod optimized;
-pub mod temporal;
+pub mod reasoning;
 pub mod scheduler;
-pub mod attractor;
-pub mod temporal_neural;
 pub mod strange_loop;
+pub mod temporal;
+pub mod temporal_neural;
+pub mod types;
 
-pub use reasoning::{FormalReasoner, Theorem, Proof, ProofStep};
-pub use agent::{AgenticLoop, Action, Observation, Plan, LearningSignal};
-pub use knowledge::{KnowledgeGraph, TheoremStore, Entity, Relation};
-pub use learning::{StreamLearner, OnlineModel, AdaptationStrategy};
-pub use types::{AgentState, Context, Reward};
-pub use optimized::{
-    FeatureCache, BufferPool, PredictionCache, BatchProcessor,
-    FastEntityExtractor, fast_hash, simd,
-};
-pub use temporal::{
-    TemporalComparator, Sequence, ComparisonAlgorithm, CacheStats,
-};
-pub use scheduler::{
-    RealtimeScheduler, ScheduledTask, SchedulingPolicy, Priority,
-    SchedulableAction, SchedulerStats,
-};
+pub use agent::{Action, AgenticLoop, LearningSignal, Observation, Plan};
 pub use attractor::{
-    AttractorAnalyzer, BehaviorAttractorAnalyzer, AttractorType,
-    AttractorInfo, Trajectory, PhasePoint, BehaviorSummary,
+    AttractorAnalyzer, AttractorInfo, AttractorType, BehaviorAttractorAnalyzer, BehaviorSummary,
+    PhasePoint, Trajectory,
 };
-pub use temporal_neural::{
-    TemporalNeuralSolver, TemporalFormula, TemporalOperator,
-    TemporalTrace, TemporalState, VerificationResult,
-};
+pub use knowledge::{Entity, KnowledgeGraph, Relation, TheoremStore};
+pub use learning::{AdaptationStrategy, OnlineModel, StreamLearner};
 pub use midstreamer_strange_loop::{
-    MetaLearner, MetaLevel, MetaKnowledge, StrangeLoop,
-    ModificationRule, SafetyConstraint, MetaLearningSummary,
+    MetaKnowledge, MetaLearner, MetaLearningSummary, MetaLevel, ModificationRule, SafetyConstraint,
+    StrangeLoop,
 };
+pub use optimized::{
+    fast_hash, simd, BatchProcessor, BufferPool, FastEntityExtractor, FeatureCache, PredictionCache,
+};
+pub use reasoning::{FormalReasoner, Proof, ProofStep, Theorem};
+pub use scheduler::{
+    Priority, RealtimeScheduler, SchedulableAction, ScheduledTask, SchedulerStats, SchedulingPolicy,
+};
+pub use temporal::{CacheStats, ComparisonAlgorithm, Sequence, TemporalComparator};
+pub use temporal_neural::{
+    TemporalFormula, TemporalNeuralSolver, TemporalOperator, TemporalState, TemporalTrace,
+    VerificationResult,
+};
+pub use types::{AgentState, Context, Reward};
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -177,11 +173,13 @@ impl LeanAgenticSystem {
         learner.update(&action, reward, chunk).await?;
 
         // 6. Learn from experience
-        agent.learn(LearningSignal {
-            action: action.clone(),
-            observation: observation.clone(),
-            reward,
-        }).await?;
+        agent
+            .learn(LearningSignal {
+                action: action.clone(),
+                observation: observation.clone(),
+                reward,
+            })
+            .await?;
 
         Ok(ProcessingResult {
             action,

--- a/src/lean_agentic/optimized.rs
+++ b/src/lean_agentic/optimized.rs
@@ -7,8 +7,8 @@
 //! - Cached predictions
 //! - Batch processing
 
-use super::types::*;
 use super::agent::Action;
+use super::types::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -66,7 +66,9 @@ impl BufferPool {
     }
 
     pub fn acquire(&mut self) -> Vec<u8> {
-        self.buffers.pop().unwrap_or_else(|| Vec::with_capacity(self.buffer_size))
+        self.buffers
+            .pop()
+            .unwrap_or_else(|| Vec::with_capacity(self.buffer_size))
     }
 
     pub fn release(&mut self, mut buffer: Vec<u8>) {
@@ -199,7 +201,10 @@ impl<T> BatchProcessor<T> {
         self.batch.push(item);
 
         if self.batch.len() >= self.batch_size {
-            Some(std::mem::replace(&mut self.batch, Vec::with_capacity(self.batch_size)))
+            Some(std::mem::replace(
+                &mut self.batch,
+                Vec::with_capacity(self.batch_size),
+            ))
         } else {
             None
         }
@@ -296,7 +301,9 @@ impl<'a> MessageParser<'a> {
         }
 
         let start = self.position;
-        while self.position < self.data.len() && !self.data.as_bytes()[self.position].is_ascii_whitespace() {
+        while self.position < self.data.len()
+            && !self.data.as_bytes()[self.position].is_ascii_whitespace()
+        {
             self.position += 1;
         }
 
@@ -304,7 +311,9 @@ impl<'a> MessageParser<'a> {
     }
 
     fn skip_whitespace(&mut self) {
-        while self.position < self.data.len() && self.data.as_bytes()[self.position].is_ascii_whitespace() {
+        while self.position < self.data.len()
+            && self.data.as_bytes()[self.position].is_ascii_whitespace()
+        {
             self.position += 1;
         }
     }

--- a/src/lean_agentic/reasoning.rs
+++ b/src/lean_agentic/reasoning.rs
@@ -1,11 +1,11 @@
 //! Formal reasoning engine inspired by Lean theorem proving
 
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
-use async_trait::async_trait;
 
-use super::types::Context;
 use super::agent::Action;
+use super::types::Context;
 
 /// Formal reasoning engine for verifying agent actions
 pub struct FormalReasoner {
@@ -65,11 +65,7 @@ impl FormalReasoner {
     }
 
     /// Verify an action is safe and correct
-    pub async fn verify_action(
-        &self,
-        action: &Action,
-        context: &Context,
-    ) -> Result<Proof, String> {
+    pub async fn verify_action(&self, action: &Action, context: &Context) -> Result<Proof, String> {
         let proof_key = format!("{:?}_{}", action, context.session_id);
 
         // Check cache first
@@ -109,9 +105,7 @@ impl FormalReasoner {
         });
 
         // Compute overall validity
-        proof.confidence = proof.steps.iter()
-            .map(|s| s.confidence)
-            .product::<f64>();
+        proof.confidence = proof.steps.iter().map(|s| s.confidence).product::<f64>();
 
         proof.valid = proof.confidence > 0.5;
 
@@ -120,7 +114,9 @@ impl FormalReasoner {
 
     async fn verify_safety(&self, action: &Action) -> f64 {
         // Check against safety axioms
-        let safety_axiom = self.theorem_base.iter()
+        let safety_axiom = self
+            .theorem_base
+            .iter()
             .find(|t| t.tags.contains(&"safety".to_string()));
 
         if let Some(_axiom) = safety_axiom {
@@ -266,10 +262,9 @@ mod tests {
     async fn test_formal_reasoner() {
         let mut reasoner = FormalReasoner::new();
 
-        let theorem = reasoner.prove_theorem(
-            "Q".to_string(),
-            vec!["P".to_string(), "P -> Q".to_string()],
-        ).await;
+        let theorem = reasoner
+            .prove_theorem("Q".to_string(), vec!["P".to_string(), "P -> Q".to_string()])
+            .await;
 
         assert!(theorem.is_ok());
     }

--- a/src/lean_agentic/strange_loop.rs
+++ b/src/lean_agentic/strange_loop.rs
@@ -269,14 +269,19 @@ impl MetaLearner {
                     levels: vec![level_sequence[i], level_sequence[i + 1]],
                     description: format!(
                         "Oscillation between {:?} and {:?}",
-                        level_sequence[i], level_sequence[i + 1]
+                        level_sequence[i],
+                        level_sequence[i + 1]
                     ),
                     strength: 0.5,
                     is_beneficial: true, // Assume beneficial unless proven otherwise
                 };
 
                 // Check if loop already exists
-                if !self.strange_loops.iter().any(|l| l.levels == strange_loop.levels) {
+                if !self
+                    .strange_loops
+                    .iter()
+                    .any(|l| l.levels == strange_loop.levels)
+                {
                     self.strange_loops.push(strange_loop);
                 }
             }
@@ -322,16 +327,12 @@ impl MetaLearner {
     pub fn self_modify(&mut self, rule: ModificationRule) -> Result<(), String> {
         // Check safety constraints
         for constraint in &mut self.safety_constraints {
-            if rule.action.contains("infinite")
-                && constraint.name == "no_infinite_loops"
-            {
+            if rule.action.contains("infinite") && constraint.name == "no_infinite_loops" {
                 constraint.is_violated = true;
                 return Err(format!("Safety constraint violated: {}", constraint.name));
             }
 
-            if rule.action.contains("core")
-                && constraint.name == "preserve_core_functionality"
-            {
+            if rule.action.contains("core") && constraint.name == "preserve_core_functionality" {
                 constraint.is_violated = true;
                 return Err(format!("Safety constraint violated: {}", constraint.name));
             }

--- a/src/lean_agentic/temporal.rs
+++ b/src/lean_agentic/temporal.rs
@@ -8,8 +8,8 @@
 
 use lru::LruCache;
 use serde::{Deserialize, Serialize};
-use std::hash::{Hash, Hasher};
 use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 use std::num::NonZeroUsize;
 
 /// Comparison algorithm selection
@@ -76,12 +76,7 @@ impl<T: Clone + PartialEq + Hash> TemporalComparator<T> {
     }
 
     /// Compare two sequences using specified algorithm
-    pub fn compare(
-        &mut self,
-        seq1: &[T],
-        seq2: &[T],
-        algorithm: ComparisonAlgorithm,
-    ) -> f64 {
+    pub fn compare(&mut self, seq1: &[T], seq2: &[T], algorithm: ComparisonAlgorithm) -> f64 {
         // Check cache first
         let cache_key = SequencePair {
             id1: format!("{:?}", seq1),
@@ -242,14 +237,12 @@ impl<T: Clone + PartialEq + Hash> TemporalComparator<T> {
         }
 
         // Sort by similarity (best first)
-        results.sort_by(|a, b| {
-            match algorithm {
-                ComparisonAlgorithm::DTW | ComparisonAlgorithm::EditDistance => {
-                    a.1.partial_cmp(&b.1).unwrap()
-                }
-                ComparisonAlgorithm::LCS | ComparisonAlgorithm::Correlation => {
-                    b.1.partial_cmp(&a.1).unwrap()
-                }
+        results.sort_by(|a, b| match algorithm {
+            ComparisonAlgorithm::DTW | ComparisonAlgorithm::EditDistance => {
+                a.1.partial_cmp(&b.1).unwrap()
+            }
+            ComparisonAlgorithm::LCS | ComparisonAlgorithm::Correlation => {
+                b.1.partial_cmp(&a.1).unwrap()
             }
         });
 
@@ -278,10 +271,22 @@ impl<T: Clone + PartialEq + Hash> TemporalComparator<T> {
         CacheStats {
             cache_size: self.cache.len(),
             total_comparisons: self.algorithm_cache.values().sum(),
-            dtw_count: *self.algorithm_cache.get(&ComparisonAlgorithm::DTW).unwrap_or(&0),
-            lcs_count: *self.algorithm_cache.get(&ComparisonAlgorithm::LCS).unwrap_or(&0),
-            edit_distance_count: *self.algorithm_cache.get(&ComparisonAlgorithm::EditDistance).unwrap_or(&0),
-            correlation_count: *self.algorithm_cache.get(&ComparisonAlgorithm::Correlation).unwrap_or(&0),
+            dtw_count: *self
+                .algorithm_cache
+                .get(&ComparisonAlgorithm::DTW)
+                .unwrap_or(&0),
+            lcs_count: *self
+                .algorithm_cache
+                .get(&ComparisonAlgorithm::LCS)
+                .unwrap_or(&0),
+            edit_distance_count: *self
+                .algorithm_cache
+                .get(&ComparisonAlgorithm::EditDistance)
+                .unwrap_or(&0),
+            correlation_count: *self
+                .algorithm_cache
+                .get(&ComparisonAlgorithm::Correlation)
+                .unwrap_or(&0),
         }
     }
 

--- a/src/lean_agentic/temporal_neural.rs
+++ b/src/lean_agentic/temporal_neural.rs
@@ -99,11 +99,7 @@ impl TemporalFormula {
     }
 
     /// Create bounded eventually (for MTL)
-    pub fn eventually_bounded(
-        formula: TemporalFormula,
-        lower: Duration,
-        upper: Duration,
-    ) -> Self {
+    pub fn eventually_bounded(formula: TemporalFormula, lower: Duration, upper: Duration) -> Self {
         TemporalFormula::BoundedTemporal {
             operator: TemporalOperator::Eventually,
             formula: Box::new(formula),
@@ -113,11 +109,7 @@ impl TemporalFormula {
     }
 
     /// Create bounded globally (for MTL)
-    pub fn globally_bounded(
-        formula: TemporalFormula,
-        lower: Duration,
-        upper: Duration,
-    ) -> Self {
+    pub fn globally_bounded(formula: TemporalFormula, lower: Duration, upper: Duration) -> Self {
         TemporalFormula::BoundedTemporal {
             operator: TemporalOperator::Globally,
             formula: Box::new(formula),
@@ -269,7 +261,11 @@ impl TemporalNeuralSolver {
                             if holds { "true" } else { "false" },
                             position
                         ),
-                        counterexample: if holds { None } else { Some(vec![name.clone()]) },
+                        counterexample: if holds {
+                            None
+                        } else {
+                            Some(vec![name.clone()])
+                        },
                     }
                 } else {
                     VerificationResult {
@@ -402,7 +398,10 @@ impl TemporalNeuralSolver {
                             return VerificationResult {
                                 holds: true,
                                 confidence: result.confidence,
-                                explanation: format!("Eventually at position {}: {}", i, result.explanation),
+                                explanation: format!(
+                                    "Eventually at position {}: {}",
+                                    i, result.explanation
+                                ),
                                 counterexample: None,
                             };
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
 //! MidStream: Real-Time Large Language Model Streaming Platform
-//! 
+//!
 //! This library provides functionality for real-time LLM response streaming,
 //! inflight data analysis, and integration with external tools.
-//! 
+//!
 //! # Example
-//! 
+//!
 //! ```rust,no_run
 //! use midstream::{Midstream, HyprSettings, HyprServiceImpl, StreamProcessor, LLMClient};
 //! use bytes::Bytes;
@@ -24,7 +24,7 @@
 //!         ]))
 //!     }
 //! }
-//! 
+//!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     // Initialize settings
@@ -59,8 +59,8 @@
 //! ```
 
 pub mod config;
-pub mod midstream;
 pub mod hypr_service;
+pub mod midstream;
 pub mod tests;
 
 // `lean_agentic` is the legacy in-tree subsystem that ADR-0005 retires.
@@ -72,43 +72,18 @@ pub mod tests;
 pub mod lean_agentic;
 
 pub use config::HyprSettings;
-pub use midstream::{
-    Midstream,
-    StreamProcessor,
-    LLMMessage,
-    LLMClient,
-    HyprService,
-    ToolIntegration,
-    Intent,
-    MetricRecord,
-    TimeWindow,
-    AggregateFunction,
-};
 pub use hypr_service::HyprServiceImpl;
+pub use midstream::{
+    AggregateFunction, HyprService, Intent, LLMClient, LLMMessage, MetricRecord, Midstream,
+    StreamProcessor, TimeWindow, ToolIntegration,
+};
 
 // Lean Agentic Learning System exports — gated behind the same feature.
 // Once ADR-0005's dedup ships, the canonical home for these types is
 // the published `midstreamer-*` crates; this re-export block goes away.
 #[cfg(feature = "lean-agentic")]
 pub use lean_agentic::{
-    LeanAgenticSystem,
-    LeanAgenticConfig,
-    FormalReasoner,
-    Theorem,
-    Proof,
-    ProofStep,
-    AgenticLoop,
-    Action,
-    Observation,
-    Plan,
-    LearningSignal,
-    KnowledgeGraph,
-    Entity,
-    Relation,
-    StreamLearner,
-    OnlineModel,
-    AdaptationStrategy,
-    AgentState,
-    Context as AgentContext,
-    Reward,
+    Action, AdaptationStrategy, AgentState, AgenticLoop, Context as AgentContext, Entity,
+    FormalReasoner, KnowledgeGraph, LeanAgenticConfig, LeanAgenticSystem, LearningSignal,
+    Observation, OnlineModel, Plan, Proof, ProofStep, Relation, Reward, StreamLearner, Theorem,
 };

--- a/src/midstream.rs
+++ b/src/midstream.rs
@@ -1,11 +1,11 @@
-use std::borrow::Cow;
-use std::sync::Arc;
-use std::time::Duration;
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::Mutex;
-use serde::{Serialize, Deserialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MetricRecord {
@@ -63,7 +63,10 @@ impl LLMMessage {
 pub trait StreamProcessor {
     async fn process_stream(&self) -> Result<Vec<LLMMessage>, Box<dyn std::error::Error>>;
     async fn get_metrics(&self) -> Vec<MetricRecord>;
-    async fn get_average_sentiment(&self, window: Duration) -> Result<f64, Box<dyn std::error::Error>>;
+    async fn get_average_sentiment(
+        &self,
+        window: Duration,
+    ) -> Result<f64, Box<dyn std::error::Error>>;
 }
 
 /// Source of LLM token chunks.
@@ -81,7 +84,11 @@ pub trait LLMClient: Send + Sync {
 #[async_trait]
 pub trait HyprService: Send + Sync {
     async fn ingest_metric(&self, metric: MetricRecord) -> Result<(), Box<dyn std::error::Error>>;
-    async fn query_aggregate(&self, window: TimeWindow, func: AggregateFunction) -> Result<f64, Box<dyn std::error::Error>>;
+    async fn query_aggregate(
+        &self,
+        window: TimeWindow,
+        func: AggregateFunction,
+    ) -> Result<f64, Box<dyn std::error::Error>>;
 }
 
 pub trait ToolIntegration: Send + Sync {
@@ -97,10 +104,7 @@ pub struct Midstream {
 }
 
 impl Midstream {
-    pub fn new(
-        llm_client: Box<dyn LLMClient>,
-        hypr_service: Box<dyn HyprService>,
-    ) -> Self {
+    pub fn new(llm_client: Box<dyn LLMClient>, hypr_service: Box<dyn HyprService>) -> Self {
         Self {
             llm_client,
             hypr_service,
@@ -137,7 +141,10 @@ impl Midstream {
         content.to_uppercase().starts_with("URGENT")
     }
 
-    async fn process_message(&self, content: Bytes) -> Result<LLMMessage, Box<dyn std::error::Error>> {
+    async fn process_message(
+        &self,
+        content: Bytes,
+    ) -> Result<LLMMessage, Box<dyn std::error::Error>> {
         // Validate content
         if content.is_empty() {
             return Err("Empty message content".into());
@@ -204,7 +211,7 @@ impl Midstream {
 impl StreamProcessor for Midstream {
     async fn process_stream(&self) -> Result<Vec<LLMMessage>, Box<dyn std::error::Error>> {
         use futures::StreamExt;
-        
+
         let mut messages = Vec::new();
         let mut stream = self.llm_client.stream();
 
@@ -220,11 +227,16 @@ impl StreamProcessor for Midstream {
         self.metrics.lock().await.clone()
     }
 
-    async fn get_average_sentiment(&self, window: Duration) -> Result<f64, Box<dyn std::error::Error>> {
+    async fn get_average_sentiment(
+        &self,
+        window: Duration,
+    ) -> Result<f64, Box<dyn std::error::Error>> {
         let minutes = window.as_secs() / 60;
-        self.hypr_service.query_aggregate(
-            TimeWindow::Minutes(minutes as u32),
-            AggregateFunction::Average,
-        ).await
+        self.hypr_service
+            .query_aggregate(
+                TimeWindow::Minutes(minutes as u32),
+                AggregateFunction::Average,
+            )
+            .await
     }
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,10 +1,13 @@
 #[cfg(test)]
 mod tests {
-    use crate::midstream::{Midstream, StreamProcessor, Intent, LLMClient, HyprService, ToolIntegration, MetricRecord, TimeWindow, AggregateFunction};
-    use std::time::Duration;
+    use crate::midstream::{
+        AggregateFunction, HyprService, Intent, LLMClient, MetricRecord, Midstream,
+        StreamProcessor, TimeWindow, ToolIntegration,
+    };
     use bytes::Bytes;
-    use mockall::*;
     use futures::stream::{self, BoxStream};
+    use mockall::*;
+    use std::time::Duration;
 
     type BoxError = Box<dyn std::error::Error>;
 
@@ -35,24 +38,18 @@ mod tests {
     async fn test_stream_processing_with_metrics() {
         let mut mock_llm = MockLLMClient::new();
         let mut mock_hypr = MockHyprService::new();
-        
-        mock_llm.expect_stream()
-            .times(1)
-            .return_once(move || {
-                Box::pin(stream::iter(vec![
-                    Bytes::from_static(b"Process"),
-                    Bytes::from_static(b"this"),
-                    Bytes::from_static(b"stream"),
-                ]))
-            });
 
-        mock_hypr.expect_ingest_metric()
-            .returning(|_| Ok(()));
+        mock_llm.expect_stream().times(1).return_once(move || {
+            Box::pin(stream::iter(vec![
+                Bytes::from_static(b"Process"),
+                Bytes::from_static(b"this"),
+                Bytes::from_static(b"stream"),
+            ]))
+        });
 
-        let midstream = Midstream::new(
-            Box::new(mock_llm),
-            Box::new(mock_hypr),
-        );
+        mock_hypr.expect_ingest_metric().returning(|_| Ok(()));
+
+        let midstream = Midstream::new(Box::new(mock_llm), Box::new(mock_hypr));
 
         let result = midstream.process_stream().await;
         assert!(result.is_ok());
@@ -66,16 +63,16 @@ mod tests {
         let mut mock_llm = MockLLMClient::new();
         let mut mock_hypr = MockHyprService::new();
 
-        mock_hypr.expect_query_aggregate()
+        mock_hypr
+            .expect_query_aggregate()
             .times(1)
             .return_once(|_, _| Ok(0.75));
 
-        let midstream = Midstream::new(
-            Box::new(mock_llm),
-            Box::new(mock_hypr),
-        );
+        let midstream = Midstream::new(Box::new(mock_llm), Box::new(mock_hypr));
 
-        let avg = midstream.get_average_sentiment(Duration::from_secs(300)).await;
+        let avg = midstream
+            .get_average_sentiment(Duration::from_secs(300))
+            .await;
         assert!(avg.is_ok());
         assert_eq!(avg.unwrap(), 0.75);
     }
@@ -85,24 +82,24 @@ mod tests {
         let mut mock_llm = MockLLMClient::new();
         let mut mock_hypr = MockHyprService::new();
 
-        mock_hypr.expect_ingest_metric()
+        mock_hypr
+            .expect_ingest_metric()
             .times(1)
             .return_once(|_| Err("Ingestion error".into()));
 
-        mock_llm.expect_stream()
+        mock_llm
+            .expect_stream()
             .times(1)
-            .return_once(|| {
-                Box::pin(stream::iter(vec![Bytes::from_static(b"test message")]))
-            });
+            .return_once(|| Box::pin(stream::iter(vec![Bytes::from_static(b"test message")])));
 
-        let midstream = Midstream::new(
-            Box::new(mock_llm),
-            Box::new(mock_hypr),
-        );
+        let midstream = Midstream::new(Box::new(mock_llm), Box::new(mock_hypr));
 
         let result = midstream.process_stream().await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Failed to ingest metric"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Failed to ingest metric"));
     }
 
     #[tokio::test]
@@ -110,16 +107,12 @@ mod tests {
         let mut mock_llm = MockLLMClient::new();
         let mut mock_hypr = MockHyprService::new();
 
-        mock_llm.expect_stream()
+        mock_llm
+            .expect_stream()
             .times(1)
-            .return_once(|| {
-                Box::pin(stream::iter(Vec::<Bytes>::new()))
-            });
+            .return_once(|| Box::pin(stream::iter(Vec::<Bytes>::new())));
 
-        let midstream = Midstream::new(
-            Box::new(mock_llm),
-            Box::new(mock_hypr),
-        );
+        let midstream = Midstream::new(Box::new(mock_llm), Box::new(mock_hypr));
 
         let result = midstream.process_stream().await;
         assert!(result.is_ok());
@@ -130,25 +123,20 @@ mod tests {
     async fn test_large_message_processing() {
         let mut mock_llm = MockLLMClient::new();
         let mut mock_hypr = MockHyprService::new();
-        
+
         let large_message = Bytes::from(vec![b'x'; 1_000_000]);
-        mock_llm.expect_stream()
+        mock_llm
+            .expect_stream()
             .times(1)
-            .return_once(move || {
-                Box::pin(stream::iter(vec![large_message]))
-            });
+            .return_once(move || Box::pin(stream::iter(vec![large_message])));
 
-        mock_hypr.expect_ingest_metric()
-            .returning(|_| Ok(()));
+        mock_hypr.expect_ingest_metric().returning(|_| Ok(()));
 
-        let midstream = Midstream::new(
-            Box::new(mock_llm),
-            Box::new(mock_hypr),
-        );
+        let midstream = Midstream::new(Box::new(mock_llm), Box::new(mock_hypr));
 
         let result = midstream.process_stream().await;
         assert!(result.is_ok());
-        
+
         let messages = result.unwrap();
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].content.len(), 1_000_000);
@@ -160,20 +148,18 @@ mod tests {
         let mut mock_hypr = MockHyprService::new();
         let mut mock_tool = MockToolClient::new();
 
-        mock_llm.expect_stream()
-            .times(1)
-            .return_once(|| {
-                Box::pin(stream::iter(vec![
-                    Bytes::from_static(b"URGENT: What's the weather"),
-                ]))
-            });
+        mock_llm.expect_stream().times(1).return_once(|| {
+            Box::pin(stream::iter(vec![Bytes::from_static(
+                b"URGENT: What's the weather",
+            )]))
+        });
 
-        mock_tool.expect_handle_weather_intent()
+        mock_tool
+            .expect_handle_weather_intent()
             .times(1)
             .return_once(|_| Ok("Weather info (urgent response)".to_string()));
 
-        mock_hypr.expect_ingest_metric()
-            .returning(|_| Ok(()));
+        mock_hypr.expect_ingest_metric().returning(|_| Ok(()));
 
         let midstream = Midstream::with_tool_integration(
             Box::new(mock_llm),
@@ -186,7 +172,11 @@ mod tests {
         let messages = result.unwrap();
 
         assert_eq!(messages[0].intent, Some(Intent::Weather));
-        assert!(messages[0].tool_response.as_ref().unwrap().contains("urgent response"));
+        assert!(messages[0]
+            .tool_response
+            .as_ref()
+            .unwrap()
+            .contains("urgent response"));
     }
 
     #[tokio::test]
@@ -194,19 +184,18 @@ mod tests {
         let mut mock_llm = MockLLMClient::new();
         let mut mock_hypr = MockHyprService::new();
 
-        mock_llm.expect_stream()
+        mock_llm
+            .expect_stream()
             .times(1)
-            .return_once(|| {
-                Box::pin(stream::iter(vec![Bytes::new()]))
-            });
+            .return_once(|| Box::pin(stream::iter(vec![Bytes::new()])));
 
-        let midstream = Midstream::new(
-            Box::new(mock_llm),
-            Box::new(mock_hypr),
-        );
+        let midstream = Midstream::new(Box::new(mock_llm), Box::new(mock_hypr));
 
         let result = midstream.process_stream().await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Empty message content"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Empty message content"));
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -11,11 +11,13 @@
 use std::time::Duration;
 
 // Import from published crates
-use midstreamer_temporal_compare::{TemporalComparator, Sequence, ComparisonAlgorithm};
-use midstreamer_scheduler::{RealtimeScheduler, SchedulerConfig, Priority, Deadline};
-use midstreamer_attractor::{AttractorAnalyzer, PhasePoint, AttractorType};
-use midstreamer_neural_solver::{TemporalNeuralSolver, TemporalFormula, TemporalState, VerificationStrictness};
-use midstreamer_strange_loop::{StrangeLoop, MetaLevel, StrangeLoopConfig};
+use midstreamer_attractor::{AttractorAnalyzer, AttractorType, PhasePoint};
+use midstreamer_neural_solver::{
+    TemporalFormula, TemporalNeuralSolver, TemporalState, VerificationStrictness,
+};
+use midstreamer_scheduler::{Deadline, Priority, RealtimeScheduler, SchedulerConfig};
+use midstreamer_strange_loop::{MetaLevel, StrangeLoop, StrangeLoopConfig};
+use midstreamer_temporal_compare::{ComparisonAlgorithm, Sequence, TemporalComparator};
 
 /// Test 1: Scheduler + Temporal Compare Integration
 ///
@@ -42,7 +44,9 @@ fn test_scheduler_temporal_integration() {
     seq2.push("complete".to_string(), 200);
 
     // Compare sequences to detect patterns
-    let result = comparator.compare(&seq1, &seq2, ComparisonAlgorithm::DTW).unwrap();
+    let result = comparator
+        .compare(&seq1, &seq2, ComparisonAlgorithm::DTW)
+        .unwrap();
     println!("  Pattern similarity (DTW): {:.4}", result.distance);
     assert!(result.distance < 1.0, "Should detect identical patterns");
 
@@ -53,13 +57,18 @@ fn test_scheduler_temporal_integration() {
         Priority::Medium
     };
 
-    let task_id = scheduler.schedule(
-        "pattern_based_task".to_string(),
-        Deadline::from_millis(100),
-        priority,
-    ).unwrap();
+    let task_id = scheduler
+        .schedule(
+            "pattern_based_task".to_string(),
+            Deadline::from_millis(100),
+            priority,
+        )
+        .unwrap();
 
-    println!("  ✓ Task {} scheduled with {:?} priority", task_id, priority);
+    println!(
+        "  ✓ Task {} scheduled with {:?} priority",
+        task_id, priority
+    );
     assert_eq!(scheduler.queue_size(), 1);
 
     // Verify task retrieval
@@ -108,11 +117,9 @@ fn test_scheduler_attractor_integration() {
             Priority::Low
         };
 
-        scheduler.schedule(
-            i as f64,
-            Deadline::from_millis((i + 10) as u64),
-            priority,
-        ).unwrap();
+        scheduler
+            .schedule(i as f64, Deadline::from_millis((i + 10) as u64), priority)
+            .unwrap();
     }
 
     // Analyze attractor to understand system stability
@@ -120,7 +127,10 @@ fn test_scheduler_attractor_integration() {
     println!("  Attractor type: {:?}", attractor_info.attractor_type);
     println!("  Stable: {}", attractor_info.is_stable);
     println!("  Confidence: {:.2}", attractor_info.confidence);
-    println!("  Max Lyapunov: {:.4}", attractor_info.max_lyapunov_exponent().unwrap_or(0.0));
+    println!(
+        "  Max Lyapunov: {:.4}",
+        attractor_info.max_lyapunov_exponent().unwrap_or(0.0)
+    );
 
     // Verify behavior analysis
     assert_eq!(attractor_info.dimension, 3);
@@ -132,8 +142,10 @@ fn test_scheduler_attractor_integration() {
 
     // Get scheduler stats
     let stats = scheduler.stats();
-    println!("  ✓ Scheduler stats: {} total tasks, {} in queue",
-             stats.total_tasks, stats.queue_size);
+    println!(
+        "  ✓ Scheduler stats: {} total tasks, {} in queue",
+        stats.total_tasks, stats.queue_size
+    );
     assert_eq!(stats.total_tasks, 150);
 
     println!("=== Test 2 PASSED ===\n");
@@ -157,10 +169,7 @@ fn test_attractor_solver_integration() {
         let t = i as f64 * 0.1;
 
         // Create periodic trajectory
-        let point = PhasePoint::new(
-            vec![t.sin(), t.cos()],
-            i as u64 * 10,
-        );
+        let point = PhasePoint::new(vec![t.sin(), t.cos()], i as u64 * 10);
         analyzer.add_point(point).unwrap();
 
         // Record temporal state
@@ -186,8 +195,14 @@ fn test_attractor_solver_integration() {
     println!("  ✓ Bounded property: {}", bounded_result.satisfied);
     println!("  ✓ Oscillating property: {}", oscillating_result.satisfied);
 
-    assert!(bounded_result.satisfied, "Limit cycle should remain bounded");
-    assert!(oscillating_result.satisfied, "System should always oscillate");
+    assert!(
+        bounded_result.satisfied,
+        "Limit cycle should remain bounded"
+    );
+    assert!(
+        oscillating_result.satisfied,
+        "System should always oscillate"
+    );
 
     // Verify eventually periodic
     let periodic_formula = TemporalFormula::finally(TemporalFormula::atom("periodic"));
@@ -225,7 +240,9 @@ fn test_temporal_solver_integration() {
     seq2.push("safe".to_string(), 300);
 
     // Compare sequences
-    let distance = comparator.compare(&seq1, &seq2, ComparisonAlgorithm::EditDistance).unwrap();
+    let distance = comparator
+        .compare(&seq1, &seq2, ComparisonAlgorithm::EditDistance)
+        .unwrap();
     println!("  Edit distance: {:.4}", distance.distance);
     assert_eq!(distance.distance, 1.0, "Should differ by one element");
 
@@ -278,23 +295,24 @@ fn test_full_system_strange_loop() {
         "verify".to_string(),
     ];
 
-    strange_loop.learn_at_level(MetaLevel::base(), &workflow_steps).unwrap();
+    strange_loop
+        .learn_at_level(MetaLevel::base(), &workflow_steps)
+        .unwrap();
 
     // Schedule tasks for each workflow step
     for (i, step) in workflow_steps.iter().enumerate() {
-        scheduler.schedule(
-            step.clone(),
-            Deadline::from_millis((i as u64 + 1) * 100),
-            Priority::High,
-        ).unwrap();
+        scheduler
+            .schedule(
+                step.clone(),
+                Deadline::from_millis((i as u64 + 1) * 100),
+                Priority::High,
+            )
+            .unwrap();
     }
 
     // Analyze dynamics
     for i in 0..150 {
-        let point = PhasePoint::new(
-            vec![i as f64, (i as f64).sin(), (i as f64).cos()],
-            i as u64,
-        );
+        let point = PhasePoint::new(vec![i as f64, (i as f64).sin(), (i as f64).cos()], i as u64);
         analyzer.add_point(point).unwrap();
     }
 
@@ -316,7 +334,9 @@ fn test_full_system_strange_loop() {
         format!("attractor:{:?}", attractor_info.attractor_type),
         format!("stable:{}", attractor_info.is_stable),
     ];
-    strange_loop.learn_at_level(MetaLevel(1), &meta_patterns).unwrap();
+    strange_loop
+        .learn_at_level(MetaLevel(1), &meta_patterns)
+        .unwrap();
 
     // Level 2: Analyze behavioral dynamics
     println!("  Level 2: Behavioral dynamics analysis...");
@@ -436,11 +456,9 @@ fn test_performance_scalability() {
     let scheduler: RealtimeScheduler<u64> = RealtimeScheduler::default();
 
     for i in 0..1000 {
-        scheduler.schedule(
-            i,
-            Deadline::from_millis(100),
-            Priority::Medium,
-        ).unwrap();
+        scheduler
+            .schedule(i, Deadline::from_millis(100), Priority::Medium)
+            .unwrap();
     }
 
     let duration = start.elapsed();
@@ -460,10 +478,14 @@ fn test_performance_scalability() {
     }
 
     // First comparison - cache miss
-    let _result1 = comparator.compare(&seq1, &seq2, ComparisonAlgorithm::DTW).unwrap();
+    let _result1 = comparator
+        .compare(&seq1, &seq2, ComparisonAlgorithm::DTW)
+        .unwrap();
 
     // Second comparison - cache hit
-    let _result2 = comparator.compare(&seq1, &seq2, ComparisonAlgorithm::DTW).unwrap();
+    let _result2 = comparator
+        .compare(&seq1, &seq2, ComparisonAlgorithm::DTW)
+        .unwrap();
 
     let duration = start.elapsed();
     println!("  ✓ Compared 100-element sequences (2x) in {:?}", duration);
@@ -478,10 +500,7 @@ fn test_performance_scalability() {
     let mut analyzer = AttractorAnalyzer::new(3, 10000);
 
     for i in 0..1000 {
-        let point = PhasePoint::new(
-            vec![(i as f64).sin(), (i as f64).cos(), i as f64 * 0.01],
-            i,
-        );
+        let point = PhasePoint::new(vec![(i as f64).sin(), (i as f64).cos(), i as f64 * 0.01], i);
         analyzer.add_point(point).unwrap();
     }
 
@@ -549,7 +568,9 @@ fn test_state_management() {
     let mut analyzer = AttractorAnalyzer::new(2, 1000);
 
     for i in 0..50 {
-        analyzer.add_point(PhasePoint::new(vec![i as f64, i as f64], i)).unwrap();
+        analyzer
+            .add_point(PhasePoint::new(vec![i as f64, i as f64], i))
+            .unwrap();
     }
 
     assert_eq!(analyzer.trajectory_length(), 50);
@@ -574,7 +595,9 @@ fn test_state_management() {
     // Test 3: Strange loop reset
     let mut strange_loop = StrangeLoop::default();
 
-    strange_loop.learn_at_level(MetaLevel::base(), &vec!["a".to_string()]).unwrap();
+    strange_loop
+        .learn_at_level(MetaLevel::base(), &vec!["a".to_string()])
+        .unwrap();
     let before = strange_loop.get_summary();
     assert!(before.total_knowledge > 0);
 
@@ -587,11 +610,13 @@ fn test_state_management() {
     let scheduler: RealtimeScheduler<String> = RealtimeScheduler::default();
 
     for i in 0..10 {
-        scheduler.schedule(
-            format!("task_{}", i),
-            Deadline::from_millis(100),
-            Priority::Medium,
-        ).unwrap();
+        scheduler
+            .schedule(
+                format!("task_{}", i),
+                Deadline::from_millis(100),
+                Priority::Medium,
+            )
+            .unwrap();
     }
 
     assert_eq!(scheduler.queue_size(), 10);
@@ -607,7 +632,9 @@ fn test_state_management() {
     seq1.push(1, 0);
     seq2.push(1, 0);
 
-    comparator.compare(&seq1, &seq2, ComparisonAlgorithm::DTW).unwrap();
+    comparator
+        .compare(&seq1, &seq2, ComparisonAlgorithm::DTW)
+        .unwrap();
     let stats_before = comparator.cache_stats();
     assert!(stats_before.size > 0 || stats_before.misses > 0);
 
@@ -633,27 +660,36 @@ fn test_deadline_priority_handling() {
     scheduler.start();
 
     // Schedule tasks with different priorities
-    let low_id = scheduler.schedule(
-        "low_priority".to_string(),
-        Deadline::from_millis(100),
-        Priority::Low,
-    ).unwrap();
+    let low_id = scheduler
+        .schedule(
+            "low_priority".to_string(),
+            Deadline::from_millis(100),
+            Priority::Low,
+        )
+        .unwrap();
 
-    let high_id = scheduler.schedule(
-        "high_priority".to_string(),
-        Deadline::from_millis(100),
-        Priority::High,
-    ).unwrap();
+    let high_id = scheduler
+        .schedule(
+            "high_priority".to_string(),
+            Deadline::from_millis(100),
+            Priority::High,
+        )
+        .unwrap();
 
-    let critical_id = scheduler.schedule(
-        "critical_priority".to_string(),
-        Deadline::from_millis(100),
-        Priority::Critical,
-    ).unwrap();
+    let critical_id = scheduler
+        .schedule(
+            "critical_priority".to_string(),
+            Deadline::from_millis(100),
+            Priority::Critical,
+        )
+        .unwrap();
 
     // Verify priority ordering
     let task1 = scheduler.next_task().unwrap();
-    assert_eq!(task1.id, critical_id, "Critical priority should execute first");
+    assert_eq!(
+        task1.id, critical_id,
+        "Critical priority should execute first"
+    );
     assert_eq!(task1.priority, Priority::Critical);
 
     let task2 = scheduler.next_task().unwrap();
@@ -668,11 +704,9 @@ fn test_deadline_priority_handling() {
     std::thread::sleep(Duration::from_millis(10));
     let past_deadline = Deadline::from_micros(1);
 
-    scheduler.schedule(
-        "late_task".to_string(),
-        past_deadline,
-        Priority::High,
-    ).unwrap();
+    scheduler
+        .schedule("late_task".to_string(), past_deadline, Priority::High)
+        .unwrap();
 
     let late_task = scheduler.next_task().unwrap();
     scheduler.execute_task(late_task, |_payload| {

--- a/tests/simulation_tests.rs
+++ b/tests/simulation_tests.rs
@@ -1,8 +1,8 @@
 //! Comprehensive simulation tests for various real-world scenarios
 
 use midstream::{
-    LeanAgenticSystem, LeanAgenticConfig, AgentContext,
-    KnowledgeGraph, Entity, EntityType, Relation,
+    AgentContext, Entity, EntityType, KnowledgeGraph, LeanAgenticConfig, LeanAgenticSystem,
+    Relation,
 };
 use std::time::Instant;
 
@@ -53,7 +53,10 @@ async fn test_knowledge_accumulation_simulation() {
     ];
 
     for msg in &learning_sequence {
-        let result = system.process_stream_chunk(msg, context.clone()).await.unwrap();
+        let result = system
+            .process_stream_chunk(msg, context.clone())
+            .await
+            .unwrap();
         context.add_message(msg.to_string());
         context.set_preference("detail_level".to_string(), 0.9);
     }
@@ -97,10 +100,17 @@ async fn test_high_frequency_streaming_simulation() {
     println!("  Total chunks: {}", num_chunks);
     println!("  Duration: {:?}", duration);
     println!("  Throughput: {:.2} chunks/sec", chunks_per_sec);
-    println!("  Avg latency: {:.2} ms/chunk", duration.as_millis() as f64 / num_chunks as f64);
+    println!(
+        "  Avg latency: {:.2} ms/chunk",
+        duration.as_millis() as f64 / num_chunks as f64
+    );
 
     // Verify minimum throughput
-    assert!(chunks_per_sec > 50.0, "Throughput too low: {:.2} chunks/sec", chunks_per_sec);
+    assert!(
+        chunks_per_sec > 50.0,
+        "Throughput too low: {:.2} chunks/sec",
+        chunks_per_sec
+    );
 }
 
 #[tokio::test]
@@ -117,14 +127,12 @@ async fn test_concurrent_sessions_simulation() {
         let sys = &system;
         let handle = tokio::spawn(async move {
             let context = AgentContext::new(format!("session_{}", i));
-            let messages = vec![
-                "Hello",
-                "What's the weather?",
-                "Thank you",
-            ];
+            let messages = vec!["Hello", "What's the weather?", "Thank you"];
 
             for msg in messages {
-                sys.process_stream_chunk(msg, context.clone()).await.unwrap();
+                sys.process_stream_chunk(msg, context.clone())
+                    .await
+                    .unwrap();
             }
         });
         handles.push(handle);
@@ -139,7 +147,10 @@ async fn test_concurrent_sessions_simulation() {
     println!("\nConcurrent sessions results:");
     println!("  Sessions: {}", num_sessions);
     println!("  Duration: {:?}", duration);
-    println!("  Avg per session: {:.2} ms", duration.as_millis() as f64 / num_sessions as f64);
+    println!(
+        "  Avg per session: {:.2} ms",
+        duration.as_millis() as f64 / num_sessions as f64
+    );
 
     let stats = system.get_stats().await;
     println!("  Total actions: {}", stats.total_actions);
@@ -160,7 +171,10 @@ async fn test_learning_convergence_simulation() {
     let mut rewards = vec![];
 
     for iteration in 0..100 {
-        let result = system.process_stream_chunk(pattern, context.clone()).await.unwrap();
+        let result = system
+            .process_stream_chunk(pattern, context.clone())
+            .await
+            .unwrap();
         rewards.push(result.reward);
 
         if iteration % 10 == 0 {
@@ -180,7 +194,10 @@ async fn test_learning_convergence_simulation() {
     println!("  Improvement: {:.3}", late_avg - early_avg);
 
     // Rewards should stabilize or improve
-    assert!(late_avg >= early_avg * 0.8, "Learning degraded significantly");
+    assert!(
+        late_avg >= early_avg * 0.8,
+        "Learning degraded significantly"
+    );
 }
 
 #[tokio::test]
@@ -233,7 +250,10 @@ async fn test_knowledge_graph_scaling() {
     println!("\nKnowledge graph scaling results:");
     println!("  Entities inserted: {}", num_entities);
     println!("  Insert time: {:?}", insert_duration);
-    println!("  Insert rate: {:.2} entities/sec", num_entities as f64 / insert_duration.as_secs_f64());
+    println!(
+        "  Insert rate: {:.2} entities/sec",
+        num_entities as f64 / insert_duration.as_secs_f64()
+    );
     println!("  Relations added: 1000");
     println!("  Relation time: {:?}", relation_duration);
     println!("  Query time: {:?}", query_duration);
@@ -257,7 +277,10 @@ async fn test_adaptive_behavior_simulation() {
     println!("\nPhase 1: Weather queries");
     for i in 0..10 {
         let msg = format!("What's the weather in city {}?", i);
-        let result = system.process_stream_chunk(&msg, context.clone()).await.unwrap();
+        let result = system
+            .process_stream_chunk(&msg, context.clone())
+            .await
+            .unwrap();
         context.add_message(msg);
         if i == 0 || i == 9 {
             println!("  Iteration {}: reward = {:.3}", i, result.reward);
@@ -268,7 +291,10 @@ async fn test_adaptive_behavior_simulation() {
     println!("\nPhase 2: Learning queries");
     for i in 0..10 {
         let msg = format!("Remember that I like {}", i);
-        let result = system.process_stream_chunk(&msg, context.clone()).await.unwrap();
+        let result = system
+            .process_stream_chunk(&msg, context.clone())
+            .await
+            .unwrap();
         context.add_message(msg);
         if i == 0 || i == 9 {
             println!("  Iteration {}: reward = {:.3}", i, result.reward);
@@ -305,6 +331,8 @@ async fn test_memory_efficiency() {
     let stats = system.get_stats().await;
     println!("  Sessions processed: 100");
     println!("  Total entities: {}", stats.total_entities);
-    println!("  Estimated memory per session: ~{} KB",
-             (stats.total_entities * size_of::<Entity>()) / 100 / 1024);
+    println!(
+        "  Estimated memory per session: ~{} KB",
+        (stats.total_entities * size_of::<Entity>()) / 100 / 1024
+    );
 }

--- a/tests/temporal_compare_api_test.rs
+++ b/tests/temporal_compare_api_test.rs
@@ -2,8 +2,7 @@
 ///
 /// This test suite verifies that the find_similar() and detect_pattern() APIs
 /// work correctly with the published crate.
-
-use midstreamer_temporal_compare::{TemporalComparator, Pattern, SimilarityMatch};
+use midstreamer_temporal_compare::{Pattern, SimilarityMatch, TemporalComparator};
 
 #[test]
 fn test_find_similar_with_f64() {
@@ -26,7 +25,12 @@ fn test_find_similar_with_f64() {
 
     // Verify distances are within threshold
     for (idx, distance) in &matches {
-        assert!(*distance <= 1.0, "Distance {} at index {} exceeds threshold", distance, idx);
+        assert!(
+            *distance <= 1.0,
+            "Distance {} at index {} exceeds threshold",
+            distance,
+            idx
+        );
     }
 }
 
@@ -64,7 +68,9 @@ fn test_find_similar_generic_with_integers() {
     let needle = vec![3, 4, 5];
 
     // Use the generic API with normalized threshold
-    let matches = comparator.find_similar_generic(&haystack, &needle, 0.1).unwrap();
+    let matches = comparator
+        .find_similar_generic(&haystack, &needle, 0.1)
+        .unwrap();
 
     assert_eq!(matches.len(), 2, "Should find 2 exact matches");
     assert_eq!(matches[0].start_index, 2);
@@ -72,7 +78,10 @@ fn test_find_similar_generic_with_integers() {
 
     // Verify similarity scores
     for m in &matches {
-        assert!(m.similarity > 0.9, "Exact matches should have high similarity");
+        assert!(
+            m.similarity > 0.9,
+            "Exact matches should have high similarity"
+        );
     }
 }
 
@@ -84,13 +93,14 @@ fn test_detect_recurring_patterns() {
     let sequence = vec!['a', 'b', 'c', 'a', 'b', 'c', 'a', 'b', 'c'];
 
     // Detect patterns of length 3
-    let patterns = comparator.detect_recurring_patterns(&sequence, 3, 3).unwrap();
+    let patterns = comparator
+        .detect_recurring_patterns(&sequence, 3, 3)
+        .unwrap();
 
     assert!(!patterns.is_empty(), "Should detect recurring patterns");
 
     // Find the 'abc' pattern
-    let abc_pattern = patterns.iter()
-        .find(|p| p.sequence == vec!['a', 'b', 'c']);
+    let abc_pattern = patterns.iter().find(|p| p.sequence == vec!['a', 'b', 'c']);
 
     assert!(abc_pattern.is_some(), "Should find 'abc' pattern");
 
@@ -107,13 +117,18 @@ fn test_detect_fuzzy_patterns() {
     let sequence = vec![1, 2, 3, 1, 2, 4, 1, 2, 3];
 
     // Detect fuzzy patterns (should group [1,2,3] and [1,2,4] together)
-    let patterns = comparator.detect_fuzzy_patterns(&sequence, 3, 3, 0.7).unwrap();
+    let patterns = comparator
+        .detect_fuzzy_patterns(&sequence, 3, 3, 0.7)
+        .unwrap();
 
     assert!(!patterns.is_empty(), "Should detect fuzzy patterns");
 
     // Should find at least one pattern that occurs multiple times
     let has_multiple = patterns.iter().any(|p| p.frequency() >= 2);
-    assert!(has_multiple, "Should find patterns with multiple occurrences");
+    assert!(
+        has_multiple,
+        "Should find patterns with multiple occurrences"
+    );
 }
 
 #[test]
@@ -142,8 +157,10 @@ fn test_similarity_match_struct() {
 
     // Lower distance should give higher similarity
     let match2 = SimilarityMatch::new(0, 0.1);
-    assert!(match2.similarity > match1.similarity,
-        "Lower distance should yield higher similarity");
+    assert!(
+        match2.similarity > match1.similarity,
+        "Lower distance should yield higher similarity"
+    );
 }
 
 #[test]
@@ -168,7 +185,10 @@ fn test_edge_case_pattern_longer_than_series() {
     let pattern = vec![1.0, 2.0, 3.0, 4.0, 5.0];
 
     let matches = comparator.find_similar(&series, &pattern, 1.0);
-    assert!(matches.is_empty(), "Pattern longer than series should return no matches");
+    assert!(
+        matches.is_empty(),
+        "Pattern longer than series should return no matches"
+    );
 }
 
 #[test]
@@ -181,11 +201,17 @@ fn test_approximate_matching_with_threshold() {
 
     // Strict threshold - should not match
     let strict_matches = comparator.find_similar(&series, &pattern, 0.1);
-    assert!(strict_matches.is_empty(), "Strict threshold should reject approximate match");
+    assert!(
+        strict_matches.is_empty(),
+        "Strict threshold should reject approximate match"
+    );
 
     // Loose threshold - should match
     let loose_matches = comparator.find_similar(&series, &pattern, 1.5);
-    assert!(!loose_matches.is_empty(), "Loose threshold should accept approximate match");
+    assert!(
+        !loose_matches.is_empty(),
+        "Loose threshold should accept approximate match"
+    );
 }
 
 #[test]
@@ -202,12 +228,17 @@ fn test_results_sorted_by_quality() {
 
     // Verify results are sorted by distance (best first)
     for i in 0..matches.len().saturating_sub(1) {
-        assert!(matches[i].1 <= matches[i + 1].1,
-            "Results should be sorted by distance (ascending)");
+        assert!(
+            matches[i].1 <= matches[i + 1].1,
+            "Results should be sorted by distance (ascending)"
+        );
     }
 
     // First match should be the exact one
-    assert!(matches[0].1 < 0.1, "Best match should have very low distance");
+    assert!(
+        matches[0].1 < 0.1,
+        "Best match should have very low distance"
+    );
 }
 
 #[test]
@@ -221,10 +252,14 @@ fn test_caching_behavior() {
     comparator.clear_cache();
 
     // First call - should be cache miss
-    let _ = comparator.find_similar_generic(&haystack, &needle, 0.1).unwrap();
+    let _ = comparator
+        .find_similar_generic(&haystack, &needle, 0.1)
+        .unwrap();
 
     // Second call - should be cache hit
-    let _ = comparator.find_similar_generic(&haystack, &needle, 0.1).unwrap();
+    let _ = comparator
+        .find_similar_generic(&haystack, &needle, 0.1)
+        .unwrap();
 
     let stats = comparator.cache_stats();
     assert!(stats.hits > 0, "Should have cache hits");
@@ -237,31 +272,37 @@ fn test_comprehensive_workflow() {
 
     // Create a rich sequence
     let sequence = vec![
-        1, 2, 3, 4,    // Pattern A
-        1, 2, 3, 4,    // Pattern A repeat
-        5, 6, 7,       // Pattern B
-        5, 6, 7,       // Pattern B repeat
-        1, 2, 3, 4,    // Pattern A again
+        1, 2, 3, 4, // Pattern A
+        1, 2, 3, 4, // Pattern A repeat
+        5, 6, 7, // Pattern B
+        5, 6, 7, // Pattern B repeat
+        1, 2, 3, 4, // Pattern A again
     ];
 
     // Test 1: Exact pattern detection
-    let exact_patterns = comparator.detect_recurring_patterns(&sequence, 3, 4).unwrap();
+    let exact_patterns = comparator
+        .detect_recurring_patterns(&sequence, 3, 4)
+        .unwrap();
     assert!(!exact_patterns.is_empty(), "Should detect exact patterns");
 
     // Test 2: Fuzzy pattern detection
-    let fuzzy_patterns = comparator.detect_fuzzy_patterns(&sequence, 3, 4, 0.8).unwrap();
+    let fuzzy_patterns = comparator
+        .detect_fuzzy_patterns(&sequence, 3, 4, 0.8)
+        .unwrap();
     assert!(!fuzzy_patterns.is_empty(), "Should detect fuzzy patterns");
 
     // Test 3: Similarity search
     let needle = vec![1, 2, 3, 4];
-    let matches = comparator.find_similar_generic(&sequence, &needle, 0.1).unwrap();
+    let matches = comparator
+        .find_similar_generic(&sequence, &needle, 0.1)
+        .unwrap();
     assert_eq!(matches.len(), 3, "Should find 3 occurrences of pattern");
 
     // Test 4: Simple detection
     let found = comparator.detect_pattern(
         &sequence.iter().map(|&x| x as f64).collect::<Vec<_>>(),
         &needle.iter().map(|&x| x as f64).collect::<Vec<_>>(),
-        1.0
+        1.0,
     );
     assert!(found, "Pattern should be detected");
 

--- a/tests/wasm_integration_test.rs
+++ b/tests/wasm_integration_test.rs
@@ -9,15 +9,17 @@
 
 #![cfg(target_arch = "wasm32")]
 
-use wasm_bindgen_test::*;
 use std::collections::HashMap;
+use wasm_bindgen_test::*;
 
 // WASM-specific imports
-use midstreamer_temporal_compare::{TemporalComparator, Sequence, ComparisonAlgorithm};
-use midstreamer_scheduler::{RealtimeScheduler, SchedulingPolicy, Priority};
 use midstreamer_attractor::{AttractorAnalyzer, PhasePoint};
-use midstreamer_neural_solver::{TemporalNeuralSolver, TemporalFormula, TemporalState, VerificationStrictness};
-use midstreamer_strange_loop::{StrangeLoop, MetaLevel};
+use midstreamer_neural_solver::{
+    TemporalFormula, TemporalNeuralSolver, TemporalState, VerificationStrictness,
+};
+use midstreamer_scheduler::{Priority, RealtimeScheduler, SchedulingPolicy};
+use midstreamer_strange_loop::{MetaLevel, StrangeLoop};
+use midstreamer_temporal_compare::{ComparisonAlgorithm, Sequence, TemporalComparator};
 
 wasm_bindgen_test_configure!(run_in_browser);
 
@@ -60,12 +62,14 @@ async fn test_wasm_scheduler() {
 
     // Schedule multiple tasks
     for i in 0..10 {
-        scheduler.schedule(
-            create_action(&format!("wasm_task_{}", i), "WASM task"),
-            Priority::Medium,
-            std::time::Duration::from_secs(1),
-            std::time::Duration::from_millis(10),
-        ).await;
+        scheduler
+            .schedule(
+                create_action(&format!("wasm_task_{}", i), "WASM task"),
+                Priority::Medium,
+                std::time::Duration::from_secs(1),
+                std::time::Duration::from_millis(10),
+            )
+            .await;
     }
 
     let stats = scheduler.get_stats().await;
@@ -85,10 +89,7 @@ fn test_wasm_attractor_analysis() {
     // Add points
     for i in 0..150 {
         let point = PhasePoint::new(
-            vec![
-                (i as f64 * 0.1).sin(),
-                (i as f64 * 0.1).cos(),
-            ],
+            vec![(i as f64 * 0.1).sin(), (i as f64 * 0.1).cos()],
             i as u64,
         );
         analyzer.add_point(point).unwrap();
@@ -204,9 +205,9 @@ fn test_wasm_performance() {
 async fn test_wasm_concurrent_ops() {
     console_log!("=== WASM Concurrent Operations Test ===");
 
-    use wasm_bindgen_futures::spawn_local;
-    use std::sync::Arc;
     use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+    use wasm_bindgen_futures::spawn_local;
 
     let counter = Arc::new(AtomicU32::new(0));
 
@@ -232,7 +233,9 @@ async fn test_wasm_concurrent_ops() {
     }
 
     // Wait a bit for tasks to complete
-    wasm_timer::Delay::new(std::time::Duration::from_millis(100)).await.ok();
+    wasm_timer::Delay::new(std::time::Duration::from_millis(100))
+        .await
+        .ok();
 
     let count = counter.load(Ordering::SeqCst);
     console_log!("Completed {} concurrent operations", count);
@@ -272,19 +275,25 @@ async fn test_wasm_integration_workflow() {
     // Step 1: Pattern detection
     let mut comparator = TemporalComparator::<String>::new(50, 500);
     comparator.add_sequence(Sequence {
-        data: vec!["init".to_string(), "process".to_string(), "complete".to_string()],
+        data: vec![
+            "init".to_string(),
+            "process".to_string(),
+            "complete".to_string(),
+        ],
         timestamp: 1000,
         id: "workflow".to_string(),
     });
 
     // Step 2: Schedule based on pattern
     let scheduler = RealtimeScheduler::new(SchedulingPolicy::EarliestDeadlineFirst);
-    scheduler.schedule(
-        create_action("wasm_workflow", "Workflow task"),
-        Priority::High,
-        std::time::Duration::from_secs(1),
-        std::time::Duration::from_millis(50),
-    ).await;
+    scheduler
+        .schedule(
+            create_action("wasm_workflow", "Workflow task"),
+            Priority::High,
+            std::time::Duration::from_secs(1),
+            std::time::Duration::from_millis(50),
+        )
+        .await;
 
     // Step 3: Verify behavior
     let mut solver = TemporalNeuralSolver::default();

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -70,7 +70,8 @@ fn main() -> Result<()> {
     // shell-outs are stable regardless of where the user invoked
     // `cargo xtask` from. CARGO_MANIFEST_DIR points to xtask/, so
     // step one above.
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR set by cargo");
+    let manifest_dir =
+        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR set by cargo");
     sh.change_dir(format!("{manifest_dir}/.."));
 
     match args.cmd {
@@ -145,11 +146,7 @@ fn run_publish_check(sh: &Shell) -> Result<()> {
 
     for crate_name in crates {
         println!("--> cargo publish --dry-run -p {crate_name} --allow-dirty");
-        cmd!(
-            sh,
-            "cargo publish --dry-run -p {crate_name} --allow-dirty"
-        )
-        .run()?;
+        cmd!(sh, "cargo publish --dry-run -p {crate_name} --allow-dirty").run()?;
     }
 
     println!("\npublish-check ok ({} crates)", crates.len());


### PR DESCRIPTION
## Summary

Repo had accumulated rustfmt drift across \`benches/\`, \`src/\`, \`tests/\`, and \`xtask/\` — 48 files, ~1730 insertions / ~1797 deletions, all whitespace + import-ordering normalization with no behavioural change. CI's \`cargo fmt --all -- --check\` step has been red on every PR since the Format Check job was added; rebaselining now so future PRs fail only on *new* drift.

## Test plan

- [x] \`cargo fmt --all -- --check\` exits 0 post-commit
- [x] No source-level semantics touched (verified by spot-checking the diff)
- [ ] CI's Format Check turns green

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)