### PR TITLE
fix(release): drop --all-features from build-release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,14 @@ jobs:
           sudo apt-get install -y gcc-aarch64-linux-gnu
 
       - name: Build release binary
-        run: cargo build --release --target ${{ matrix.target }} --all-features
+        # No `--all-features` here: the midstream binary's
+        # `src/lean_agentic/` facade has 27 unresolved-import errors
+        # when its off-by-default `lean-agentic` feature is enabled
+        # (ADR-0005 deprecates the module; rust-ci.yml's clippy/test/
+        # docs/coverage jobs already exclude midstream for the same
+        # reason). Ship the default-feature binary; opt-in features
+        # can be re-enabled when the facade is retired.
+        run: cargo build --release --target ${{ matrix.target }}
 
       - name: Package binary (Unix)
         if: matrix.os != 'windows-latest'


### PR DESCRIPTION
## Summary

\`cargo build --release --target X --all-features\` on the midstream root crate enables the off-by-default \`lean-agentic\` feature, which exposes 27 unresolved-import errors in \`src/lean_agentic/\`. The v0.2.1 release run failed all 5 Build Release matrix entries here.

Same root cause that \`rust-ci.yml\`'s clippy/test/docs/coverage jobs already work around (and that \`release.yml\`'s publish-crates step exempts midstream from in #70). Build Release is what attaches binaries to the GitHub Release; ship default-feature builds and let opt-in features re-enable when the lean_agentic facade is retired per ADR-0005.

## Out of band: \`CARGO_REGISTRY_TOKEN\` not set

The v0.2.1 publish job failed with \`please provide a non-empty token\`. The repo's \`CARGO_REGISTRY_TOKEN\` secret is empty/unset. Only a repo admin can fix this (Settings → Secrets and variables → Actions → New repository secret). Until that's set, retagging won't publish anything.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)