### PR TITLE
docs: rewrite README in ruflo-style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2223 +1,312 @@
+<div align="center">
+
 # MidStream
 
-**Real-Time LLM Streaming with Lean Agentic Learning & Temporal Analysis**
+**Real-time LLM streaming with inflight analysis**
 
-[![License](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](#-license)
-[![Rust](https://img.shields.io/badge/Rust-1.71+-orange.svg)](https://www.rust-lang.org/)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.3+-blue.svg)](https://www.typescriptlang.org/)
-[![Node.js](https://img.shields.io/badge/Node.js-18+-green.svg)](https://nodejs.org/)
-[![WASM](https://img.shields.io/badge/WASM-Ready-purple.svg)](wasm/)
-[![Crates.io](https://img.shields.io/badge/crates.io-5%20published-orange.svg)](https://crates.io/search?q=temporal)
-[![Security](https://img.shields.io/badge/Security-A+-brightgreen.svg)](security-report.json)
-[![Tests](https://img.shields.io/badge/Tests-139%20passing-brightgreen.svg)](npm/src/__tests__)
-[![CI/CD](https://img.shields.io/badge/CI%2FCD-Active-blue.svg)](.github/workflows/)
-[![Docs](https://img.shields.io/badge/docs-complete-success.svg)](docs/)
+[![crates.io — 6 libs](https://img.shields.io/badge/crates.io-6_published_libs-orange?style=for-the-badge&logo=rust&logoColor=white)](https://crates.io/users/ruvnet)
+[![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT_OR_Apache--2.0-yellow?style=for-the-badge)](#license)
+[![MSRV: 1.81](https://img.shields.io/badge/MSRV-1.81-blue?style=for-the-badge&logo=rust&logoColor=white)](docs/adr/0023-msrv-policy.md)
+[![WASM Ready](https://img.shields.io/badge/WASM-Ready-654FF0?style=for-the-badge&logo=webassembly&logoColor=white)](#wasm--browser)
+[![QUIC Transport](https://img.shields.io/badge/QUIC-Transport-10b981?style=for-the-badge&logo=lightning&logoColor=white)](docs/adr/0021-quic-implementation-quinn.md)
 
-**🎉 All 5 Core Crates Published on crates.io!**
+[![Star on GitHub](https://img.shields.io/github/stars/ruvnet/midstream?style=for-the-badge&logo=github&color=gold)](https://github.com/ruvnet/midstream)
+[![CI](https://img.shields.io/github/actions/workflow/status/ruvnet/midstream/rust-ci.yml?branch=main&style=for-the-badge&label=CI&logo=github-actions&logoColor=white)](.github/workflows/rust-ci.yml)
+[![Supply-chain audit](https://img.shields.io/github/actions/workflow/status/ruvnet/midstream/audit.yml?branch=main&style=for-the-badge&label=audit&logo=rustsec&logoColor=white)](.github/workflows/audit.yml)
+[![ADRs: 41](https://img.shields.io/badge/ADRs-41_decisions-6366f1?style=for-the-badge&logo=adblock&logoColor=white)](docs/adr/README.md)
 
-- [temporal-compare](https://crates.io/crates/temporal-compare) • [nanosecond-scheduler](https://crates.io/crates/nanosecond-scheduler) • [temporal-attractor-studio](https://crates.io/crates/temporal-attractor-studio) • [temporal-neural-solver](https://crates.io/crates/temporal-neural-solver) • [strange-loop](https://crates.io/crates/strange-loop)
+</div>
 
-> **Created by rUv** - Advanced real-time LLM streaming platform with autonomous agents, temporal pattern detection, and multi-modal introspection.
+Treat an LLM token stream as a first-class signal — pattern-match it, score it, intervene on it — *while the tokens are still arriving*. MidStream is the Rust workspace + WASM bindings + npm shims that make that practical: a nanosecond scheduler, a multi-stream QUIC transport, dynamical-systems analysis, and a self-referential meta-learning loop, all under one consistent feature flag policy and a hard supply-chain gate.
 
----
+### Why MidStream?
 
-## 📑 Table of Contents
+> Most "LLM tooling" treats the response as a black box that opens at the end. MidStream treats it as a stream of evidence that you can analyze, gate, and steer per chunk. Built in Rust by [`rUv`](https://ruv.io) so the analysis layer adds microseconds, not seconds — and ships the same code path to native, browser, and edge via WASM.
 
-- [What is MidStream?](#-what-is-midstream)
-- [Features](#-features)
-- [Quick Start](#-quick-start)
-- [Architecture](#-architecture)
-- [Rust Workspace Crates](#-rust-workspace-crates)
-- [Installation](#-installation)
-- [WASM/Browser Support](#-wasmbrowser-support)
-- [Performance Benchmarks](#-performance-benchmarks)
-- [API Reference](#-api-reference)
-- [Examples](#-examples)
-- [Development](#-development)
-- [CI/CD](#-cicd)
-- [Testing](#-testing)
-- [Security](#-security)
-- [Contributing](#-contributing)
-- [License](#-license)
+### What MidStream Does
 
----
+One workspace, six published libraries, one binary. The libraries are independently useful (pattern matching, real-time scheduling, attractor analysis, QUIC multi-stream) and compose into a single inflight-analysis pipeline. The binary wires them together with the OpenAI Realtime API and a console dashboard.
 
-## 💡 What is MidStream?
-
-MidStream is a powerful platform that makes AI conversations smarter and more responsive. Instead of waiting for an AI to finish speaking before understanding what it's saying, MidStream analyzes responses **as they stream in real-time**—enabling instant insights, pattern detection, and intelligent decision-making.
-
-### The Problem It Solves
-
-Traditional AI systems process responses only after completion, missing opportunities to:
-- **Detect patterns early** in conversations
-- **React instantly** to user needs
-- **Analyze behavior** as it unfolds
-- **Understand context** in real-time
-- **Make predictions** before conversations end
-
-### How MidStream Helps
-
-MidStream combines cutting-edge technologies to deliver:
-
-**🎯 Real-Time Intelligence**: Analyze AI responses as they're generated, not after. Detect intents, patterns, and behaviors instantly—enabling proactive responses and smarter interactions.
-
-**🤖 Autonomous Learning**: Built-in agents that learn from every conversation, automatically adapting and improving over time without manual intervention. The system gets smarter with each interaction.
-
-**📊 Deep Pattern Analysis**: Advanced temporal analysis reveals hidden patterns in conversations, predicting user needs and detecting system behaviors that traditional analytics miss.
-
-**🎥 Multi-Modal Understanding**: Process text, audio, and video streams simultaneously. Perfect for voice assistants, video calls, live streaming platforms, and real-time customer support.
-
-**🔐 Production-Ready**: Enterprise-grade security, comprehensive testing, and performance optimization ensure reliability for mission-critical applications.
-
-### Who It's For
-
-- **Developers** building real-time AI applications
-- **Businesses** needing intelligent customer support
-- **Researchers** studying conversation dynamics
-- **Product Teams** creating voice/video AI experiences
-- **Anyone** who wants smarter, faster AI interactions
-
-Built with Rust for performance and TypeScript for flexibility, MidStream combines the best of both worlds—blazing speed with developer-friendly tools.
-
----
-
-## 🚀 Features
-
-### 🎯 Core Capabilities
-- **🔄 Real-Time LLM Streaming** - Low-latency streaming with OpenAI Realtime API & custom providers
-- **🤖 Lean Agentic Learning** - Autonomous agents with formal reasoning and meta-learning
-- **📊 Temporal Analysis** - Pattern detection, attractor analysis, and Lyapunov exponents
-- **🎥 Multi-Modal Streaming** - Text, audio, and video stream introspection (RTMP/WebRTC/HLS)
-- **📈 Real-Time Dashboard** - Minimal console UI with live metrics and visualizations
-- **🧠 Meta-Learning** - Adaptive learning from conversation patterns and behaviors
-- **🔐 Production Ready** - Comprehensive security, error handling, and performance optimization
-
-### 🎛️ Dashboard & Monitoring
-- Real-time metrics (FPS, latency, uptime, tokens)
-- Temporal analysis visualization (attractors, stability, chaos detection)
-- Pattern detection and classification
-- Multi-stream monitoring (text/audio/video)
-- Configurable refresh rates (100-1000ms)
-- Event-driven updates with memory management
-
-### 🎥 Streaming Integration
-- **QUIC/HTTP/3** - Multiplexed transport with 0-RTT and stream prioritization
-- **RTMP/RTMPS** - Real-Time Messaging Protocol support
-- **WebRTC** - Peer-to-peer audio/video streaming
-- **HLS** - HTTP Live Streaming support
-- **WebSocket/SSE** - Bidirectional and server-sent events
-- Audio transcription framework (Whisper-ready)
-- Video object detection framework (TensorFlow-ready)
-
-### 🦀 Rust Workspace Crates
-- **temporal-compare** - Pattern matching with DTW, LCS, edit distance
-- **nanosecond-scheduler** - Ultra-low-latency real-time task scheduling
-- **temporal-attractor-studio** - Dynamical systems & Lyapunov analysis
-- **temporal-neural-solver** - LTL verification with neural reasoning
-- **strange-loop** - Meta-learning & self-referential systems
-
-### 🔬 Advanced Analysis
-- **Pattern Detection** - Dynamic Time Warping (DTW), LCS, edit distance
-- **Attractor Analysis** - Fixed point, periodic, chaotic behavior detection
-- **Lyapunov Exponents** - System stability measurement
-- **Meta-Learning** - Policy adaptation and reward optimization
-- **Knowledge Graphs** - Dynamic, evolving knowledge structures
-- **Temporal Logic** - Sequence analysis and prediction
-
-### 🛡️ Security & Quality
-- 10/10 security checks passed
-- No hardcoded credentials
-- HTTPS/WSS enforcement
-- Input validation & sanitization
-- Rate limiting & error handling
-- Comprehensive test coverage (100% new code)
-
----
-
-## 📦 Quick Start
-
-### Prerequisites
-```bash
-# Required
-- Rust 1.71+ (for core engine)
-- Node.js 18+ (for CLI/Dashboard)
-- npm or yarn
-
-# Optional
-- Docker (for containerized deployment)
-- OpenAI API key (for Realtime API)
+```
+Provider stream  ──▶  zero-copy Bytes  ──▶  inflight pipeline  ──▶  decisions
+   (OpenAI RT,         (ADR-0006)             │
+    Anthropic,                                ├─ temporal-compare    (DTW, LCS, edit-distance)
+    custom)                                   ├─ scheduler           (ns-scale priority queue)
+                                              ├─ attractor-studio    (Lyapunov, phase-space)
+                                              ├─ neural-solver       (LTL + neural reasoning)
+                                              ├─ strange-loop        (meta-learning)
+                                              └─ quic-multistream    (transport, 0-RTT)
+                                                       │
+                                              AIMDS safety gate (optional)
+                                                       │
+                                                       ▼
+                                              Dashboard · MCP · WASM · npm
 ```
 
-### Installation
+> **New to MidStream?** Start with one crate. `temporal-compare` and `scheduler` ship clean tests, run on WASM, and have zero unsafe code — they're the easiest entry points. Move up to `strange-loop` once you want the full meta-learning loop.
+
+---
+
+## Quick Start
+
+Three different entry points depending on what you need. Pick one:
+
+| | **Single library** | **Full workspace** | **WASM / browser** |
+|---|---|---|---|
+| What it gives you | One crate (e.g. just pattern matching) | All 6 libs + binary + dashboard | Same Rust code, compiled to WASM, in npm |
+| What lives in your tree | A line in your `Cargo.toml` | Cloned repo, full build | `npm install @midstream/wasm` |
+| Best for | Embedding analysis in an existing app | Running the full inflight pipeline | Browser apps, edge workers |
+
+### Path A — One crate
 
 ```bash
-# Clone the repository
+# Pattern matching only
+cargo add midstreamer-temporal-compare
+
+# Real-time scheduler only
+cargo add midstreamer-scheduler
+
+# Or the full library stack
+cargo add midstreamer-temporal-compare midstreamer-scheduler \
+          midstreamer-attractor midstreamer-neural-solver \
+          midstreamer-strange-loop midstreamer-quic
+```
+
+### Path B — Full workspace
+
+```bash
 git clone https://github.com/ruvnet/midstream.git
 cd midstream
 
-# Install Node.js dependencies
-cd npm
-npm install
+# Build everything
+cargo build --workspace --release
 
-# Build TypeScript
-npm run build:ts
-```
+# Run the binary
+cargo run --release --bin midstream -- --help
 
-### Run the Dashboard Demo
-
-```bash
-# Full demo with all features
-npm run demo
-
-# Specific demos
-npm run demo:text    # Text streaming only
-npm run demo:audio   # Audio streaming only
-npm run demo:video   # Video streaming only
-npm run demo:openai  # OpenAI Realtime API
-
-# QUIC demos
-npm run quic-demo              # Interactive QUIC demo
-npm run quic-demo:server       # QUIC server
-npm run quic-demo:client       # QUIC client
-npm run quic-demo:multistream  # Multi-stream demo
-npm run quic-demo:benchmark    # Performance benchmark
-```
-
-### Basic Usage
-
-#### Real-Time Dashboard
-```typescript
-import { MidStreamDashboard } from 'midstream-cli';
-
-const dashboard = new MidStreamDashboard();
-dashboard.start(100); // Refresh every 100ms
-
-// Process messages
-dashboard.processMessage('Hello, world!', 5);
-
-// Process streams
-const audioData = Buffer.alloc(1024);
-dashboard.processStream('audio-1', audioData, 'audio');
-```
-
-#### OpenAI Realtime Integration
-```typescript
-import { OpenAIRealtimeClient } from 'midstream-cli';
-
-const client = new OpenAIRealtimeClient({
-  apiKey: process.env.OPENAI_API_KEY,
-  model: 'gpt-4o-realtime-preview-2024-10-01',
-  voice: 'alloy'
-});
-
-client.on('response.text.delta', (delta) => {
-  console.log(delta);
-});
-
-await client.connect();
-client.sendText('Analyze this conversation...');
-```
-
-#### Restream Integration
-```typescript
-import { RestreamClient } from 'midstream-cli';
-
-const client = new RestreamClient({
-  webrtcSignaling: 'wss://signaling.example.com',
-  enableTranscription: true,
-  enableObjectDetection: true
-});
-
-client.on('frame', (frame) => {
-  console.log(`Frame ${frame.frameNumber}`);
-});
-
-await client.connectWebRTC();
-```
-
-#### QUIC Integration
-```typescript
-import { createQuicServer, connectQuic } from 'midstream-cli';
-
-// Server
-const server = createQuicServer({ port: 4433, maxStreams: 1000 });
-server.on('connection', (connection) => {
-  connection.on('stream', (stream) => {
-    stream.on('data', (data) => {
-      console.log('Received:', data.toString());
-    });
-  });
-});
-await server.listen();
-
-// Client
-const connection = await connectQuic('localhost', 4433);
-const stream = await connection.openBiStream({ priority: 10 });
-stream.write('Hello QUIC!');
-```
-
----
-
-## 🏗️ Architecture
-
-MidStream is built as a modern, modular workspace combining high-performance Rust crates with flexible TypeScript/Node.js tooling.
-
-### System Architecture
-
-```
-┌─────────────────────────────────────────────────────────────────────┐
-│                      MidStream Platform                             │
-├─────────────────────────────────────────────────────────────────────┤
-│                                                                     │
-│  ┌─────────────────────────────────────────────────────┐           │
-│  │         TypeScript/Node.js Layer                    │           │
-│  │  ┌──────────────┐  ┌──────────────┐  ┌──────────┐  │           │
-│  │  │  Dashboard   │  │  OpenAI RT   │  │  QUIC    │  │           │
-│  │  │  (Console)   │  │  Client      │  │  Client  │  │           │
-│  │  └──────┬───────┘  └──────┬───────┘  └────┬─────┘  │           │
-│  └─────────┼──────────────────┼───────────────┼────────┘           │
-│            │                  │               │                    │
-│  ┌─────────┼──────────────────┼───────────────┼────────┐           │
-│  │         │    WASM Bindings Layer           │        │           │
-│  │  ┌──────▼───────┐  ┌──────▼───────┐  ┌────▼─────┐  │           │
-│  │  │ Lean Agentic │  │  Temporal    │  │  QUIC    │  │           │
-│  │  │    WASM      │  │  Analysis    │  │  Multi   │  │           │
-│  │  └──────┬───────┘  └──────┬───────┘  └────┬─────┘  │           │
-│  └─────────┼──────────────────┼───────────────┼────────┘           │
-│            │                  │               │                    │
-│  ┌─────────┴──────────────────┴───────────────┴────────┐           │
-│  │              Rust Core Workspace                    │           │
-│  │  ┌─────────────────┐  ┌─────────────────┐           │           │
-│  │  │ temporal-       │  │ nanosecond-     │           │           │
-│  │  │ compare         │  │ scheduler       │           │           │
-│  │  │ (Pattern Match) │  │ (Real-time)     │           │           │
-│  │  └─────────────────┘  └─────────────────┘           │           │
-│  │                                                      │           │
-│  │  ┌─────────────────┐  ┌─────────────────┐           │           │
-│  │  │ temporal-       │  │ temporal-neural-│           │           │
-│  │  │ attractor-      │  │ solver          │           │           │
-│  │  │ studio          │  │ (LTL Logic)     │           │           │
-│  │  └─────────────────┘  └─────────────────┘           │           │
-│  │                                                      │           │
-│  │  ┌─────────────────┐  ┌─────────────────┐           │           │
-│  │  │ strange-loop    │  │ quic-           │           │           │
-│  │  │ (Meta-Learn)    │  │ multistream     │           │           │
-│  │  └─────────────────┘  └─────────────────┘           │           │
-│  └──────────────────────────────────────────────────────┘           │
-│                                                                     │
-└─────────────────────────────────────────────────────────────────────┘
-          │                   │                    │
-          ▼                   ▼                    ▼
-    ┌──────────┐      ┌──────────────┐    ┌──────────────┐
-    │ OpenAI   │      │ Restream     │    │ Custom       │
-    │ Realtime │      │ (RTMP/WebRTC)│    │ Providers    │
-    │ API      │      │              │    │              │
-    └──────────┘      └──────────────┘    └──────────────┘
-```
-
-### Workspace Structure
-
-```
-midstream/
-├── crates/                           # Rust workspace (6 crates, 3,171 LOC)
-│   ├── temporal-compare/             # Pattern matching & sequence analysis
-│   ├── nanosecond-scheduler/         # Ultra-low-latency scheduling
-│   ├── temporal-attractor-studio/    # Dynamical systems analysis
-│   ├── temporal-neural-solver/       # Temporal logic verification
-│   ├── strange-loop/                 # Meta-learning & self-reference
-│   └── quic-multistream/             # QUIC/HTTP3 transport (native + WASM)
-├── npm/                              # TypeScript/Node.js packages
-│   ├── src/                          # Source code
-│   │   ├── agent.ts                  # Lean Agentic learning
-│   │   ├── dashboard.ts              # Real-time dashboard
-│   │   ├── openai-realtime.ts        # OpenAI Realtime API
-│   │   ├── restream-integration.ts   # Video streaming
-│   │   ├── streaming.ts              # WebSocket/SSE
-│   │   └── mcp-server.ts             # MCP protocol
-│   ├── examples/                     # Demo applications
-│   └── __tests__/                    # 104 tests (100% passing)
-├── wasm-bindings/                    # WASM compilation target
-├── hyprstream-main/                  # Core streaming engine
-├── examples/                         # Rust examples
-└── docs/                             # Documentation
-
-Total: 6 Rust crates, 139 tests passing, 3,171+ LOC
-```
-
-### Component Overview
-
-| Component | Purpose | Technology | Status | Tests |
-|-----------|---------|-----------|--------|-------|
-| **temporal-compare** | Pattern matching, DTW, LCS | Rust | ✅ Production | 8/8 |
-| **nanosecond-scheduler** | Real-time task scheduling | Rust + Tokio | ✅ Production | 6/6 |
-| **temporal-attractor-studio** | Dynamical systems analysis | Rust + nalgebra | ✅ Production | 6/6 |
-| **temporal-neural-solver** | LTL verification & logic | Rust + ndarray | ✅ Production | 7/7 |
-| **strange-loop** | Meta-learning framework | Rust | ✅ Production | 8/8 |
-| **quic-multistream** | QUIC/HTTP3 transport | Rust (native + WASM) | ✅ Production | 37/37 |
-| **Dashboard** | Real-time monitoring UI | TypeScript | ✅ Functional | 26/26 |
-| **OpenAI Realtime** | Text/audio streaming | TypeScript | ✅ Functional | 26/26 |
-| **Restream** | Multi-protocol video | TypeScript | ✅ Framework | 15/15 |
-
-### Integration Patterns
-
-1. **Native Rust → WASM**: High-performance crates compile to WebAssembly
-2. **TypeScript → WASM**: Node.js interfaces with WASM modules
-3. **Streaming Protocols**: QUIC, WebSocket, SSE, RTMP, WebRTC
-4. **Multi-Modal**: Text, audio, video processing in parallel
-5. **Event-Driven**: Reactive architecture with async/await
-
----
-
-## 🦀 Rust Workspace Crates
-
-MidStream provides **five published Rust crates** available on [crates.io](https://crates.io/), plus one local workspace crate. All core crates are production-ready and actively maintained.
-
-### Published Crates on crates.io
-
-All five core crates are published and ready to use in your projects:
-
-- **[temporal-compare](https://crates.io/crates/temporal-compare)** v0.1.x
-- **[nanosecond-scheduler](https://crates.io/crates/nanosecond-scheduler)** v0.1.x
-- **[temporal-attractor-studio](https://crates.io/crates/temporal-attractor-studio)** v0.1.x
-- **[temporal-neural-solver](https://crates.io/crates/temporal-neural-solver)** v0.1.x
-- **[strange-loop](https://crates.io/crates/strange-loop)** v0.1.x
-
-Simply add them to your `Cargo.toml`:
-
-```toml
-[dependencies]
-temporal-compare = "0.1"
-nanosecond-scheduler = "0.1"
-temporal-attractor-studio = "0.1"
-temporal-neural-solver = "0.1"
-strange-loop = "0.1"
-```
-
-### 1. temporal-compare
-
-[![Crates.io](https://img.shields.io/crates/v/temporal-compare.svg)](https://crates.io/crates/temporal-compare)
-[![Documentation](https://docs.rs/temporal-compare/badge.svg)](https://docs.rs/temporal-compare)
-
-**Advanced temporal sequence comparison and pattern matching**
-
-```toml
-[dependencies]
-temporal-compare = "0.1"
-```
-
-**Features:**
-- Dynamic Time Warping (DTW) for sequence alignment
-- Longest Common Subsequence (LCS) detection
-- Edit Distance (Levenshtein) computation
-- Pattern matching with caching
-- Efficient LRU cache for repeated comparisons
-
-**Quick Start:**
-```rust
-use temporal_compare::{Sequence, TemporalElement, SequenceComparator};
-
-// Create sequences
-let seq1 = Sequence {
-    elements: vec![
-        TemporalElement { value: "hello", timestamp: 0 },
-        TemporalElement { value: "world", timestamp: 100 },
-    ]
-};
-
-// Compare sequences
-let comparator = SequenceComparator::new();
-let distance = comparator.dtw_distance(&seq1, &seq2)?;
-let lcs = comparator.lcs(&seq1, &seq2)?;
-```
-
-**Performance:**
-- DTW: O(n×m) with optimized dynamic programming
-- LCS: O(n×m) with space optimization
-- Edit Distance: O(n×m) with configurable weights
-- Cache hit rate: >85% for typical workloads
-
-**Platform Support:** Native (Linux, macOS, Windows), WASM
-
----
-
-### 2. nanosecond-scheduler
-
-[![Crates.io](https://img.shields.io/crates/v/nanosecond-scheduler.svg)](https://crates.io/crates/nanosecond-scheduler)
-[![Documentation](https://docs.rs/nanosecond-scheduler/badge.svg)](https://docs.rs/nanosecond-scheduler)
-
-**Ultra-low-latency real-time task scheduler**
-
-```toml
-[dependencies]
-nanosecond-scheduler = "0.1"
-```
-
-**Features:**
-- Nanosecond-precision scheduling
-- Priority-based task queues
-- Lock-free concurrent execution
-- Deadline-aware scheduling
-- Zero-allocation hot paths
-
-**Quick Start:**
-```rust
-use nanosecond_scheduler::{Scheduler, Task, Priority};
-use std::time::Duration;
-
-let scheduler = Scheduler::new(4); // 4 worker threads
-
-// Schedule high-priority task
-scheduler.schedule(Task {
-    priority: Priority::High,
-    deadline: Duration::from_millis(10),
-    work: Box::new(|| {
-        // Ultra-low-latency work
-    }),
-})?;
-
-scheduler.run().await?;
-```
-
-**Performance:**
-- Scheduling latency: <50 nanoseconds (p50)
-- Throughput: >1M tasks/second
-- Jitter: <100 nanoseconds (p99)
-- Zero allocations in hot path
-
-**Platform Support:** Native (Linux, macOS, Windows)
-
----
-
-### 3. temporal-attractor-studio
-
-[![Crates.io](https://img.shields.io/crates/v/temporal-attractor-studio.svg)](https://crates.io/crates/temporal-attractor-studio)
-[![Documentation](https://docs.rs/temporal-attractor-studio/badge.svg)](https://docs.rs/temporal-attractor-studio)
-
-**Dynamical systems and strange attractors analysis**
-
-```toml
-[dependencies]
-temporal-attractor-studio = "0.1"
-```
-
-**Features:**
-- Fixed-point attractor detection
-- Periodic orbit analysis
-- Chaotic behavior detection
-- Lyapunov exponent calculation
-- Phase space reconstruction
-
-**Quick Start:**
-```rust
-use temporal_attractor_studio::{AttractorAnalyzer, SystemState};
-
-let analyzer = AttractorAnalyzer::new();
-
-// Analyze time series
-let states: Vec<SystemState> = vec![/* ... */];
-let attractor = analyzer.detect_attractor(&states)?;
-let lyapunov = analyzer.compute_lyapunov_exponent(&states)?;
-
-match attractor {
-    AttractorType::FixedPoint(point) => println!("Stable at {:?}", point),
-    AttractorType::Periodic(period) => println!("Period: {}", period),
-    AttractorType::Chaotic => println!("Chaotic behavior detected"),
-}
-```
-
-**Performance:**
-- Attractor detection: <5ms for 1000-point series
-- Lyapunov computation: <10ms for 1000 points
-- Phase space reconstruction: O(n log n)
-
-**Platform Support:** Native (Linux, macOS, Windows), WASM
-
----
-
-### 4. temporal-neural-solver
-
-[![Crates.io](https://img.shields.io/crates/v/temporal-neural-solver.svg)](https://crates.io/crates/temporal-neural-solver)
-[![Documentation](https://docs.rs/temporal-neural-solver/badge.svg)](https://docs.rs/temporal-neural-solver)
-
-**Temporal logic verification with neural reasoning**
-
-```toml
-[dependencies]
-temporal-neural-solver = "0.1"
-```
-
-**Features:**
-- Linear Temporal Logic (LTL) verification
-- Neural network integration for pattern learning
-- Sequence prediction
-- Temporal constraint solving
-- Proof generation
-
-**Quick Start:**
-```rust
-use temporal_neural_solver::{LTLSolver, Formula, Trace};
-
-let solver = LTLSolver::new();
-
-// Define LTL formula: "always (request → eventually response)"
-let formula = Formula::always(
-    Formula::implies(
-        Formula::atomic("request"),
-        Formula::eventually(Formula::atomic("response"))
-    )
-);
-
-// Verify trace
-let trace: Trace = vec![/* state sequence */];
-let result = solver.verify(&formula, &trace)?;
-```
-
-**Performance:**
-- Formula verification: <1ms for simple formulas
-- Neural prediction: <2ms per prediction
-- Proof generation: <5ms for typical proofs
-
-**Platform Support:** Native (Linux, macOS, Windows)
-
----
-
-### 5. strange-loop
-
-[![Crates.io](https://img.shields.io/crates/v/strange-loop.svg)](https://crates.io/crates/strange-loop)
-[![Documentation](https://docs.rs/strange-loop/badge.svg)](https://docs.rs/strange-loop)
-
-**Self-referential systems and meta-learning**
-
-```toml
-[dependencies]
-strange-loop = "0.1"
-```
-
-**Features:**
-- Meta-learning framework
-- Self-referential system modeling
-- Policy adaptation
-- Reward optimization
-- Knowledge graph integration
-- Experience replay
-
-**Quick Start:**
-```rust
-use strange_loop::{MetaLearner, Policy, Experience};
-
-let mut learner = MetaLearner::new();
-
-// Learn from experience
-let experience = Experience {
-    state: vec![1.0, 2.0, 3.0],
-    action: "move_forward",
-    reward: 1.5,
-    next_state: vec![1.1, 2.1, 3.1],
-};
-
-learner.update(&experience)?;
-
-// Adapt policy
-let new_policy = learner.adapt_policy()?;
-let action = new_policy.select_action(&state)?;
-```
-
-**Performance:**
-- Policy update: <3ms per experience
-- Meta-learning iteration: <10ms
-- Knowledge graph query: <1ms
-- Experience replay: >10K samples/second
-
-**Platform Support:** Native (Linux, macOS, Windows), WASM
-
----
-
-### 6. quic-multistream
-
-**QUIC/HTTP3 multiplexed streaming (native + WASM)** - *Local workspace crate*
-
-> **Note**: This crate is currently a local workspace crate and not yet published to crates.io. The five crates above are all published and available for use.
-
-```toml
-[dependencies]
-quic-multistream = { path = "crates/quic-multistream" }  # Local only
-```
-
-**Features:**
-- QUIC protocol support (0-RTT, multiplexing)
-- WebTransport for WASM targets
-- Stream prioritization
-- Bidirectional and unidirectional streams
-- Congestion control
-- Native and browser support
-
-**Quick Start (Native):**
-```rust
-use quic_multistream::native::{QuicServer, QuicClient};
-
-// Server
-let server = QuicServer::bind("0.0.0.0:4433").await?;
-while let Some(conn) = server.accept().await {
-    let stream = conn.accept_bi().await?;
-    // Handle stream
-}
-
-// Client
-let client = QuicClient::connect("localhost:4433").await?;
-let stream = client.open_bi().await?;
-stream.write_all(b"Hello QUIC!").await?;
-```
-
-**Quick Start (WASM/Browser):**
-```rust
-use quic_multistream::wasm::WebTransport;
-
-let transport = WebTransport::connect("https://example.com:4433").await?;
-let stream = transport.create_bidirectional_stream().await?;
-// Use stream in browser
-```
-
-**Performance:**
-- 0-RTT connection establishment
-- Multiplexing: 1000+ concurrent streams
-- Throughput: Line-rate on modern hardware
-- Latency: <1ms overhead vs raw TCP
-
-**Platform Support:** Native (Linux, macOS, Windows), WASM (browser via WebTransport)
-
----
-
-## 📦 Installation
-
-### Prerequisites
-
-**Required:**
-- **Rust 1.71+** - For using published crates
-  ```bash
-  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-  ```
-- **Node.js 18+** - For TypeScript/CLI tools (optional)
-  ```bash
-  # Using nvm (recommended)
-  nvm install 18
-  nvm use 18
-  ```
-
-**Optional:**
-- **wasm-pack** - For WASM compilation
-  ```bash
-  cargo install wasm-pack
-  ```
-- **Docker** - For containerized deployments
-- **OpenAI API Key** - For Realtime API integration
-
-### Quick Install
-
-#### Option 1: Use Published Crates (Recommended)
-
-All five core crates are published on [crates.io](https://crates.io/) and ready to use:
-
-```bash
-# Create a new Rust project
-cargo new my-midstream-app
-cd my-midstream-app
-```
-
-Add to your `Cargo.toml`:
-
-```toml
-[dependencies]
-# Published MidStream crates from crates.io
-temporal-compare = "0.1"
-nanosecond-scheduler = "0.1"
-temporal-attractor-studio = "0.1"
-temporal-neural-solver = "0.1"
-strange-loop = "0.1"
-
-# For QUIC support (local workspace crate, not yet published)
-# quic-multistream = { git = "https://github.com/ruvnet/midstream", branch = "main" }
-```
-
-Then build your project:
-
-```bash
-cargo build --release
-```
-
-**That's it!** All dependencies will be downloaded from crates.io automatically.
-
-#### Option 2: From npm (Coming Soon)
-
-```bash
-# Install CLI globally
-npm install -g midstream-cli
-
-# Or use in project
-npm install midstream-cli
-```
-
-#### Option 3: From Source (Development)
-
-For development or to use the latest features:
-
-```bash
-# Clone repository
-git clone https://github.com/ruvnet/midstream.git
-cd midstream
-
-# Install Node.js dependencies
-cd npm
-npm install
-
-# Build TypeScript
-npm run build:ts
-
-# Build Rust workspace
-cd ..
-cargo build --release --workspace
-
-# Build WASM (optional)
-cd wasm-bindings
-wasm-pack build --target nodejs --out-dir ../npm/wasm
-```
-
-#### Option 4: Individual Published Crates
-
-Install specific crates as needed:
-
-```toml
-[dependencies]
-# Use only the crates you need from crates.io
-temporal-compare = "0.1"        # Pattern matching and DTW
-nanosecond-scheduler = "0.1"    # Real-time scheduling
-temporal-attractor-studio = "0.1"  # Dynamical systems analysis
-temporal-neural-solver = "0.1"  # LTL verification
-strange-loop = "0.1"            # Meta-learning
-
-# Additional dependencies
-tokio = { version = "1.42", features = ["full"] }
-serde = { version = "1.0", features = ["derive"] }
-```
-
-Browse crates on crates.io:
-- 📦 [temporal-compare](https://crates.io/crates/temporal-compare)
-- 📦 [nanosecond-scheduler](https://crates.io/crates/nanosecond-scheduler)
-- 📦 [temporal-attractor-studio](https://crates.io/crates/temporal-attractor-studio)
-- 📦 [temporal-neural-solver](https://crates.io/crates/temporal-neural-solver)
-- 📦 [strange-loop](https://crates.io/crates/strange-loop)
-
-### Verify Installation
-
-```bash
-# Check Rust installation
-cargo --version
-rustc --version
-
-# Check Node.js installation
-node --version
-npm --version
-
-# Run tests
-cd npm && npm test           # TypeScript tests
-cd .. && cargo test          # Rust tests
-
-# Run demos
-cd npm && npm run demo       # Interactive dashboard
-```
-
----
-
-## 🌐 WASM/Browser Support
-
-MidStream crates compile to WebAssembly for browser and edge deployment.
-
-### Browser Integration
-
-#### Install via npm
-
-```bash
-npm install midstream-wasm
-```
-
-#### Use in Browser
-
-```html
-<!DOCTYPE html>
-<html>
-<head>
-  <script type="module">
-    import init, { MidStreamAgent, QuicClient } from './midstream_wasm.js';
-
-    async function main() {
-      // Initialize WASM
-      await init();
-
-      // Create agent
-      const agent = new MidStreamAgent();
-      agent.process_message("Hello from browser!", 5);
-
-      // Use QUIC via WebTransport
-      const quic = await QuicClient.connect("https://server.example.com:4433");
-      const stream = await quic.open_bi_stream();
-      stream.send("Hello QUIC from browser!");
-    }
-
-    main();
-  </script>
-</head>
-<body>
-  <h1>MidStream WASM Demo</h1>
-</body>
-</html>
-```
-
-### WASM Performance
-
-| Metric | Target | Achieved |
-|--------|--------|----------|
-| Binary Size (compressed) | <100KB | 65KB (Brotli) |
-| Load Time (3G) | <500ms | 320ms |
-| Message Processing | <1ms | 0.15ms (p50) |
-| WebSocket Send | <0.1ms | 0.05ms (p50) |
-| Throughput | >25K msg/s | 50K+ msg/s |
-
-### Supported Platforms
-
-| Platform | Native | WASM | Status |
-|----------|--------|------|--------|
-| **Linux (x86_64)** | ✅ | ✅ | Full support |
-| **Linux (ARM64)** | ✅ | ✅ | Full support |
-| **macOS (Intel)** | ✅ | ✅ | Full support |
-| **macOS (Apple Silicon)** | ✅ | ✅ | Full support |
-| **Windows (x64)** | ✅ | ✅ | Full support |
-| **Chrome/Edge** | N/A | ✅ | WebTransport |
-| **Firefox** | N/A | ⚠️ | Partial (no QUIC) |
-| **Safari** | N/A | ⚠️ | Partial (no QUIC) |
-
-### WASM Features
-
-1. **Zero-Copy Processing**: Direct buffer access when possible
-2. **WebTransport Support**: QUIC in the browser
-3. **WebSocket Fallback**: For browsers without WebTransport
-4. **Optimized Binary**: Tree-shaking and LTO enabled
-5. **Async/Await**: Native Promise integration
-
----
-
-## ⚡ Performance Benchmarks
-
-Comprehensive performance testing across all components.
-
-### Rust Crate Benchmarks
-
-Run benchmarks with:
-```bash
+# Run the bench suite
 cargo bench --workspace
 ```
 
-#### temporal-compare
+See [`docs/GETTING_STARTED.md`](docs/GETTING_STARTED.md) for the full zero-to-working-build walkthrough.
 
-```
-DTW Distance (100 elements):     time:   [245.67 µs 248.92 µs 252.48 µs]
-LCS (100 elements):              time:   [189.23 µs 191.45 µs 193.89 µs]
-Edit Distance (100 elements):    time:   [156.78 µs 158.92 µs 161.34 µs]
-Pattern Match (cached):          time:   [12.45 µs 12.78 µs 13.12 µs]
-```
-
-#### nanosecond-scheduler
-
-```
-Schedule Task (single):          time:   [45.23 ns 46.89 ns 48.67 ns]
-Schedule Task (batch of 100):    time:   [3.89 µs 4.12 µs 4.38 µs]
-Execute Task (low priority):     time:   [1.23 µs 1.28 µs 1.34 µs]
-Execute Task (high priority):    time:   [0.89 µs 0.94 µs 0.99 µs]
-Throughput:                      1.12M tasks/second
-```
-
-#### temporal-attractor-studio
-
-```
-Fixed Point Detection (1K pts):  time:   [3.45 ms 3.52 ms 3.59 ms]
-Lyapunov Exponent (1K pts):      time:   [8.92 ms 9.15 ms 9.38 ms]
-Periodic Orbit (1K pts):         time:   [4.23 ms 4.35 ms 4.47 ms]
-Chaos Detection:                 time:   [2.78 ms 2.85 ms 2.92 ms]
-```
-
-#### temporal-neural-solver
-
-```
-LTL Verification (simple):       time:   [0.89 ms 0.92 ms 0.95 ms]
-LTL Verification (complex):      time:   [3.45 ms 3.52 ms 3.59 ms]
-Neural Prediction:               time:   [1.67 ms 1.72 ms 1.77 ms]
-Proof Generation:                time:   [4.23 ms 4.35 ms 4.47 ms]
-```
-
-#### strange-loop
-
-```
-Policy Update (single exp):      time:   [2.34 ms 2.41 ms 2.48 ms]
-Meta-Learning Iteration:         time:   [8.92 ms 9.15 ms 9.38 ms]
-Knowledge Graph Query:           time:   [0.67 µs 0.72 µs 0.77 µs]
-Experience Replay (100 samples): time:   [8.45 ms 8.67 ms 8.89 ms]
-```
-
-#### quic-multistream
-
-```
-Connection Establishment (0-RTT): time:   [0.12 ms 0.15 ms 0.18 ms]
-Stream Creation:                  time:   [0.05 ms 0.06 ms 0.07 ms]
-Send 1KB:                         time:   [0.23 µs 0.25 µs 0.27 µs]
-Throughput (single stream):       4.2 Gbps
-Concurrent Streams (1000):        time:   [15.3 ms 15.8 ms 16.3 ms]
-```
-
-### End-to-End Benchmarks
-
-#### Lean Agentic System
+### Path C — WASM / browser
 
 ```bash
-cargo bench --bench lean_agentic_bench
+# In a node project
+npm install @midstream/wasm
+
+# Or build from source
+cd npm-wasm
+npm install
+npm run build:wasm
 ```
 
-```
-Action Verification:              2.34 ms (p50), 5.67 ms (p99)
-Theorem Proving:                  1.89 ms (p50), 3.45 ms (p99)
-Planning:                         4.56 ms (p50), 7.89 ms (p99)
-Knowledge Graph Update:           0.67 ms (p50), 1.23 ms (p99)
+```js
+import { TemporalCompare, Scheduler } from '@midstream/wasm';
 
-Full Pipeline (10 messages):      78.3 ms (p50), 145 ms (p99)
-Full Pipeline (100 messages):     589 ms (p50), 756 ms (p99)
-Full Pipeline (500 messages):     2.8 sec (p50), 3.7 sec (p99)
-
-Concurrent Sessions (100):        1.45 sec (p50), 2.8 sec (p99)
+const cmp = new TemporalCompare();
+const distance = cmp.dtw(seriesA, seriesB);
 ```
 
-### TypeScript/WASM Benchmarks
+---
+
+## What You Get
+
+| | Capability | What it means |
+|---|------------|---------------|
+| ⚡ | **Inflight analysis** | Pattern-match, score, and gate LLM tokens as they arrive — not after the response completes |
+| 🦀 | **6 published Rust libraries** | Each crate ships independently on crates.io with its own changelog and MSRV gate |
+| 🌐 | **WASM-first design** | Every library that doesn't touch the OS compiles to `wasm32-unknown-unknown` with no source forks |
+| 📐 | **Honest benchmarks** | `cargo bench --workspace` against real workloads, not mocks — see [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) |
+| 🔒 | **Hard supply-chain gate** | `cargo audit` + `cargo deny` block every PR; ADR-0014 |
+| 🧪 | **proptest + fuzz baseline** | Every published library has a property-test suite; `midstream-fuzz` has libfuzzer targets — ADR-0038 |
+| 🚦 | **Bounded backpressure** | Every async channel has a bound; no unbounded `mpsc`, ever — ADR-0007 |
+| 🛡️ | **Secure-by-default TLS** | QUIC defaults to the platform verifier; `SkipServerVerification` is opt-in behind an `insecure-` feature flag — ADR-0011 |
+| 📊 | **Console dashboard** | Live FPS, latency, attractor type, chaos detection, stream health — `ratatui`-based, no JS toolchain needed |
+| 🔌 | **MCP tool surface** | Namespaced, versioned tools for swarm/agent integrations — ADR-0032 |
+| 📚 | **41 ADRs** | Every architectural decision is documented; superseding is via new ADRs, not edits — [`docs/adr/`](docs/adr/README.md) |
+| 🧾 | **Dual MIT OR Apache-2.0** | Whole workspace; ADR-0036 |
+
+---
+
+## Rust Workspace
+
+Six published library crates at the same workspace version (currently `0.2.1`). Each one is independently useful and can be added without pulling the others.
+
+<details>
+<summary><strong>📦 The six libraries (click to expand)</strong></summary>
+
+| Crate | What it does | crates.io |
+|---|---|---|
+| [**midstreamer-temporal-compare**](crates/temporal-compare/) | Sequence comparison: Dynamic Time Warping (DTW), Longest Common Subsequence (LCS), edit distance, with LTL extensions | [![v](https://img.shields.io/crates/v/midstreamer-temporal-compare?label=&color=orange&logo=rust)](https://crates.io/crates/midstreamer-temporal-compare) |
+| [**midstreamer-scheduler**](crates/nanosecond-scheduler/) | Ultra-low-latency priority queue with strict `Ord` semantics (priority-major, deadline-minor). Designed for ns-scale arrival rates | [![v](https://img.shields.io/crates/v/midstreamer-scheduler?label=&color=orange&logo=rust)](https://crates.io/crates/midstreamer-scheduler) |
+| [**midstreamer-attractor**](crates/temporal-attractor-studio/) | Dynamical-systems analysis: Lyapunov exponents, phase-space reconstruction, attractor classification (fixed-point / periodic / chaotic) | [![v](https://img.shields.io/crates/v/midstreamer-attractor?label=&color=orange&logo=rust)](https://crates.io/crates/midstreamer-attractor) |
+| [**midstreamer-neural-solver**](crates/temporal-neural-solver/) | Linear Temporal Logic (LTL) verification fused with a small neural reasoner. Used for inflight safety/intent checks | [![v](https://img.shields.io/crates/v/midstreamer-neural-solver?label=&color=orange&logo=rust)](https://crates.io/crates/midstreamer-neural-solver) |
+| [**midstreamer-strange-loop**](crates/strange-loop/) | Self-referential meta-learning: the system can observe and adjust its own analysis policy mid-stream | [![v](https://img.shields.io/crates/v/midstreamer-strange-loop?label=&color=orange&logo=rust)](https://crates.io/crates/midstreamer-strange-loop) |
+| [**midstreamer-quic**](crates/quic-multistream/) | QUIC multi-stream transport (quinn-backed) for native; thin shim on the browser side. 0-RTT, stream prioritization, secure-by-default TLS | [![v](https://img.shields.io/crates/v/midstreamer-quic?label=&color=orange&logo=rust)](https://crates.io/crates/midstreamer-quic) |
+
+The `midstream` binary at the workspace root wires these into the inflight pipeline.
+
+</details>
+
+<details>
+<summary><strong>🧰 The three npm packages (click to expand)</strong></summary>
+
+| Package | What it does |
+|---|---|
+| [**@midstream/wasm**](npm-wasm/) | The Rust workspace compiled to WASM — same `temporal-compare`, `scheduler`, `attractor`, `strange-loop` available from JS/TS |
+| [**midstream**](npm/) | Node CLI + dashboard. Calls the Rust binary or `@midstream/wasm` depending on environment |
+| [**lean-agentic-js**](lean-agentic-js/) | The agentic-loop tooling (action / observation / plan / learning) as standalone JS/TS, with its own test suite |
+
+</details>
+
+<details>
+<summary><strong>🌐 WASM / browser support</strong></summary>
+
+Every Rust library that doesn't touch the OS compiles to `wasm32-unknown-unknown` from the same source tree:
 
 ```bash
-cd npm && npm run benchmark
+cargo build -p midstreamer-temporal-compare --target wasm32-unknown-unknown --no-default-features
+cargo build -p midstreamer-scheduler        --target wasm32-unknown-unknown --no-default-features
+cargo build -p midstreamer-strange-loop     --target wasm32-unknown-unknown --no-default-features
 ```
 
+The `npm-wasm/` package builds with `wasm-pack`, ships TypeScript declarations, and works in Node ≥ 18, modern browsers, and edge runtimes (Cloudflare Workers, Deno, Bun). Network egress from the WASM sandbox is gated by an allowlist — ADR-0015.
+
+</details>
+
+<details>
+<summary><strong>🏛️ Architecture overview</strong></summary>
+
 ```
-Dashboard Message Processing:     <10ms average
-Stream Processing (1MB chunks):   <5ms per chunk
-WebSocket Send:                   0.05ms (p50), 0.18ms (p99)
-SSE Receive:                      0.20ms (p50), 0.70ms (p99)
-
-Memory Usage (baseline):          45MB
-Memory Usage (1000 messages):     62MB
-Memory Usage (10K messages):      128MB
-
-Throughput (single client):       50K+ msg/s
-Throughput (100 concurrent):      25K+ msg/s
+                   ┌──────────────────────────────┐
+                   │     LLM provider stream      │
+                   │ (OpenAI RT · Anthropic · ...)│
+                   └─────────────┬────────────────┘
+                                 ▼
+                       ┌─────────────────────┐
+                       │  midstream binary   │
+                       │  (zero-copy Bytes)  │
+                       └─────────────┬───────┘
+                                 ▼
+        ┌─────────────────────────────────────────────────┐
+        │              Inflight pipeline                  │
+        │                                                 │
+        │  temporal-compare ─► scheduler ─► attractor     │
+        │           │              │            │         │
+        │           ▼              ▼            ▼         │
+        │       neural-solver  strange-loop  dashboard    │
+        └─────────────────────────────────────────────────┘
+                                 │
+                  ┌──────────────┼──────────────┐
+                  ▼              ▼              ▼
+              MCP server     WASM bundle    OTLP traces
+              (ADR-0032)     (ADR-0003)     (ADR-0010)
 ```
 
-### Performance Targets vs Achieved
+See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the long form, and [`docs/adr/`](docs/adr/README.md) for the decisions that shaped each layer.
 
-| Component | Target | Achieved | Status |
-|-----------|--------|----------|--------|
-| **Message Processing** | <20ms | 10ms (avg) | ✅ Exceeded |
-| **Scheduling Latency** | <100ns | 46ns (p50) | ✅ Exceeded |
-| **Throughput** | >50 chunks/s | >1000/s | ✅ Exceeded |
-| **Concurrent Sessions** | 100+ | 100+ | ✅ Met |
-| **WASM Binary Size** | <100KB | 65KB | ✅ Exceeded |
-| **Memory Efficiency** | <100MB | <128MB | ✅ Met |
+</details>
 
 ---
 
-## 📚 Documentation
+## Performance
 
-### Core Documentation
-- **[Dashboard Guide](plans/DASHBOARD_README.md)** - Complete dashboard usage and API reference
-- **[Implementation Summary](plans/IMPLEMENTATION_SUMMARY.md)** - Architecture and technical details
-- **[Verification Report](plans/VERIFICATION_REPORT.md)** - Complete functionality verification
-- **[Lean Agentic Guide](plans/LEAN_AGENTIC_GUIDE.md)** - Autonomous learning system guide
-- **[WASM Performance Guide](plans/WASM_PERFORMANCE_GUIDE.md)** - WebAssembly optimization guide
-- **[Benchmarks & Optimizations](plans/BENCHMARKS_AND_OPTIMIZATIONS.md)** - Performance analysis
+`cargo bench --workspace` runs the full criterion suite. Honest benchmarks against real workloads, not mocks — ADR-0009.
 
-### API Reference
+Highlights from the current baseline (Ubuntu 24.04, Ryzen 9 7950X):
 
-#### Dashboard API
-```typescript
-class MidStreamDashboard {
-  start(refreshRate: number): void
-  stop(): void
-  processMessage(message: string, tokens?: number): void
-  processStream(streamId: string, data: Buffer, type: 'audio'|'video'|'text'): void
-  getState(): DashboardState
-  getAgent(): MidStreamAgent
-}
-```
+| Operation | p50 | Notes |
+|---|---|---|
+| `temporal-compare::dtw` (128 × 128 floats) | ~38 µs | SIMD-friendly; no allocations on the hot path |
+| `scheduler::push` + `pop` (priority-major) | ~85 ns / ~120 ns | Lock-free queue, ADR-0008 |
+| `attractor::lyapunov` (1 K-point trajectory) | ~2.4 ms | Single-threaded |
+| `strange-loop` self-update cycle | ~340 µs | Per inflight observation |
+| QUIC `connect` (0-RTT, loopback) | ~180 µs | Platform verifier, ADR-0011 |
 
-#### OpenAI Realtime API
-```typescript
-class OpenAIRealtimeClient {
-  connect(): Promise<void>
-  disconnect(): void
-  sendText(text: string): void
-  sendAudio(audio: string): void
-  updateSession(config: SessionConfig): void
-  on(event: string, callback: Function): void
-}
-```
-
-#### Restream API
-```typescript
-class RestreamClient {
-  connectRTMP(): Promise<void>
-  connectWebRTC(): Promise<void>
-  connectHLS(url: string): Promise<void>
-  disconnect(): void
-  getAnalysis(): StreamAnalysis
-  on(event: string, callback: Function): void
-}
-```
-
-#### QUIC API
-```typescript
-class QuicConnection {
-  connect(): Promise<void>
-  openBiStream(config?: QuicStreamConfig): Promise<QuicStream>
-  openUniStream(config?: QuicStreamConfig): Promise<QuicStream>
-  close(): void
-  getStats(): QuicConnectionStats
-  getAgent(): MidStreamAgent
-}
-
-class QuicServer {
-  listen(): Promise<void>
-  close(): void
-  getConnectionCount(): number
-  on(event: string, callback: Function): void
-}
-
-class QuicStream {
-  write(data: Buffer | string): boolean
-  close(): void
-  setPriority(priority: number): void
-  on(event: string, callback: Function): void
-}
-```
+Full numbers (CSV + plots + methodology) in [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md).
 
 ---
 
-## 📖 Examples
+## Documentation
 
-MidStream includes comprehensive examples for all major use cases.
+Four canonical docs. Everything else is either an ADR or archived.
 
-### Example 1: Real-Time Customer Support Dashboard
+| Doc | When to read it |
+|---|---|
+| **[Architecture](docs/ARCHITECTURE.md)** | What midstream is, how the pieces fit together, where each component lives. The *how-it-works* doc. |
+| **[Getting Started](docs/GETTING_STARTED.md)** | Zero to a working local build. Prerequisites, install, first run. The *how-do-I-start* doc. |
+| **[Benchmarks](docs/BENCHMARKS.md)** | Methodology + current numbers, with the historical drift documented. The *is-it-actually-fast* doc. |
+| **[Security](docs/SECURITY.md)** | Threat model, posture, supply-chain gates, how to report issues. The *should-I-trust-it* doc. |
 
-```typescript
-import { MidStreamDashboard } from 'midstream-cli';
-import { OpenAIRealtimeClient } from 'midstream-cli';
-
-const dashboard = new MidStreamDashboard();
-const openai = new OpenAIRealtimeClient({
-  apiKey: process.env.OPENAI_API_KEY,
-  model: 'gpt-4o-realtime-preview-2024-10-01'
-});
-
-// Start real-time monitoring
-dashboard.start(100); // 100ms refresh
-
-// Connect to OpenAI Realtime
-await openai.connect();
-
-// Handle responses
-openai.on('response.text.delta', (delta) => {
-  dashboard.processMessage(delta, 5);
-
-  // Get agent analysis
-  const agent = dashboard.getAgent();
-  const patterns = agent.detectPattern(history, ['greeting', 'issue', 'resolution']);
-
-  if (patterns.confidence > 0.85) {
-    console.log(`Detected pattern: ${patterns.pattern} with ${patterns.confidence} confidence`);
-  }
-});
-
-// Send user message
-openai.sendText('I need help with my account');
-```
-
-### Example 2: Video Stream Analysis with Pattern Detection
-
-```typescript
-import { RestreamClient } from 'midstream-cli';
-import { MidStreamDashboard } from 'midstream-cli';
-
-const dashboard = new MidStreamDashboard();
-const restream = new RestreamClient({
-  enableObjectDetection: true,
-  enableTranscription: true
-});
-
-// Monitor video stream
-restream.on('frame', (frame) => {
-  dashboard.processStream(frame.streamId, frame.data, 'video');
-});
-
-// Detect objects in video
-restream.on('objects_detected', (data) => {
-  console.log(`Frame ${data.frameNumber}: ${data.objects.length} objects detected`);
-
-  // Analyze patterns over time
-  const agent = dashboard.getAgent();
-  const temporalPattern = agent.detectTemporalPattern(data.objects);
-
-  if (temporalPattern.type === 'recurring') {
-    console.log('Recurring object pattern detected');
-  }
-});
-
-await restream.connectWebRTC();
-```
-
-### Example 3: Low-Latency Multiplexed Streaming with QUIC
-
-```typescript
-import { createQuicServer, connectQuic } from 'midstream-cli';
-
-// Server
-const server = createQuicServer({
-  port: 4433,
-  maxStreams: 1000,
-  cert: './cert.pem',
-  key: './key.pem'
-});
-
-server.on('connection', (connection) => {
-  console.log('New QUIC connection');
-
-  connection.on('stream', async (stream) => {
-    // Multiplexed streams with priorities
-    stream.setPriority(stream.metadata.priority || 5);
-
-    stream.on('data', (data) => {
-      console.log(`Received on stream ${stream.id}: ${data.toString()}`);
-      stream.write(`Echo: ${data}`);
-    });
-  });
-});
-
-await server.listen();
-
-// Client
-const conn = await connectQuic('localhost', 4433);
-
-// Create multiple streams with different priorities
-const videoStream = await conn.openBiStream({ priority: 10 });
-const audioStream = await conn.openBiStream({ priority: 9 });
-const telemetryStream = await conn.openUniStream({ priority: 1 });
-
-// Send data
-videoStream.write(videoFrame);
-audioStream.write(audioChunk);
-telemetryStream.write(JSON.stringify({ cpu: 45, mem: 62 }));
-```
-
-### Example 4: Meta-Learning Agent with Strange Loop
-
-Using the published `strange-loop` crate from crates.io:
-
-```toml
-[dependencies]
-strange-loop = "0.1"  # Published on crates.io
-```
-
-```rust
-use strange_loop::{MetaLearner, Policy, Experience};
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut learner = MetaLearner::new();
-
-    // Simulate conversation learning
-    for i in 0..1000 {
-        // Collect experience from environment
-        let experience = Experience {
-            state: get_conversation_state(),
-            action: select_response(),
-            reward: get_user_feedback(),
-            next_state: get_next_state(),
-        };
-
-        // Update meta-learner
-        learner.update(&experience)?;
-
-        // Every 100 iterations, adapt policy
-        if i % 100 == 0 {
-            let new_policy = learner.adapt_policy()?;
-            println!("Policy adapted. New strategy: {:?}", new_policy.strategy);
-        }
-    }
-
-    // Get learned knowledge
-    let knowledge = learner.get_knowledge_graph()?;
-    println!("Learned {} concepts", knowledge.num_entities());
-
-    Ok(())
-}
-```
-
-### Example 5: Temporal Pattern Analysis
-
-Using published crates from crates.io:
-
-```toml
-[dependencies]
-temporal-attractor-studio = "0.1"  # Published on crates.io
-temporal-compare = "0.1"           # Published on crates.io
-```
-
-```rust
-use temporal_attractor_studio::{AttractorAnalyzer, SystemState};
-use temporal_compare::{Sequence, SequenceComparator};
-
-fn analyze_conversation_dynamics(messages: Vec<Message>) -> Result<Analysis, Error> {
-    let analyzer = AttractorAnalyzer::new();
-
-    // Convert messages to system states
-    let states: Vec<SystemState> = messages.iter()
-        .map(|m| SystemState::from_message(m))
-        .collect();
-
-    // Detect conversation attractor
-    let attractor = analyzer.detect_attractor(&states)?;
-    let lyapunov = analyzer.compute_lyapunov_exponent(&states)?;
-
-    match attractor {
-        AttractorType::FixedPoint(point) => {
-            println!("Conversation converging to stable state: {:?}", point);
-        }
-        AttractorType::Periodic(period) => {
-            println!("Periodic conversation pattern (period: {})", period);
-        }
-        AttractorType::Chaotic if lyapunov > 0.0 => {
-            println!("Chaotic conversation dynamics detected");
-        }
-        _ => println!("Complex dynamics"),
-    }
-
-    Ok(Analysis { attractor, lyapunov })
-}
-```
-
-### More Examples
-
-Browse the full example collection:
-
-- **[Dashboard Demo](npm/examples/dashboard-demo.ts)** - Full-featured dashboard demo
-- **[QUIC Demo](npm/examples/quic-demo.ts)** - Interactive QUIC client/server
-- **[OpenAI Streaming](npm/examples/openai-streaming.ts)** - Real-time OpenAI integration
-- **[Lean Agentic Streaming](examples/lean_agentic_streaming.rs)** - Rust agentic system
-- **[OpenRouter Integration](examples/openrouter.rs)** - Alternative LLM provider
-- **[QUIC Server](examples/quic_server.rs)** - Production QUIC server
+Plus the **41 [ADRs](docs/adr/README.md)** — every architectural decision, immutable, with status tracked (Proposed → Accepted → Superseded). Browse the [index](docs/adr/README.md) by topic: foundational · perf/SOTA · security · API · transport · TS surface · dashboard · governance.
 
 ---
 
-## 🛠️ Development
-
-### Building from Source
+## Development
 
 ```bash
-# Clone and setup
-git clone https://github.com/ruvnet/midstream.git
-cd midstream
+# Run the workspace tests (skip midstream root + hyprstream; broken under --all-features)
+cargo test --workspace --exclude midstream --exclude hyprstream --all-features
 
-# Install dependencies
-cd npm && npm install
+# Lint
+cargo clippy --workspace --exclude midstream --exclude hyprstream --all-targets --all-features -- -D warnings
 
-# Build all components
-npm run build          # Builds TypeScript + WASM
-npm run build:ts       # TypeScript only
-npm run build:wasm     # WASM only
+# Format check
+cargo fmt --all -- --check
 
-# Build Rust workspace
-cd ..
-cargo build --workspace
+# Supply-chain gate (matches CI)
+cargo deny --workspace check --hide-inclusion-graph advisories
+cargo deny --workspace check --hide-inclusion-graph bans
+cargo deny --workspace check --hide-inclusion-graph licenses
+cargo deny --workspace check --hide-inclusion-graph sources
+cargo audit
 
-# Build for release (optimized)
-cargo build --release --workspace
+# Property tests
+cargo test --workspace --exclude midstream --exclude hyprstream --test 'proptest_*'
 
-# Build specific crate
-cargo build -p temporal-compare --release
+# Fuzz one target
+cargo +nightly fuzz run dtw_does_not_panic -- -runs=100000
 ```
 
-### Running Tests
-
-```bash
-# TypeScript tests
-cd npm
-npm test                    # Run all tests
-npm test:watch              # Watch mode
-npm test:coverage           # With coverage
-
-# Rust tests
-cd ..
-cargo test --workspace      # All crates
-cargo test -p temporal-compare  # Specific crate
-cargo test -- --nocapture   # Show output
-
-# Integration tests
-cargo test --test '*'
-
-# Doc tests
-cargo test --doc
-```
-
-### Running Benchmarks
-
-```bash
-# Rust benchmarks
-cargo bench --workspace           # All benchmarks
-cargo bench -p nanosecond-scheduler  # Specific crate
-cargo bench -- --save-baseline main  # Save baseline
-
-# TypeScript benchmarks (if available)
-cd npm && npm run benchmark
-```
-
-### Code Quality
-
-```bash
-# Rust
-cargo fmt --all --check     # Format check
-cargo clippy --all-targets  # Linting
-cargo audit                 # Security audit
-
-# TypeScript
-npm run lint                # ESLint
-npm run format              # Prettier
-```
-
-### Project Structure Details
-
-```
-midstream/
-├── .github/
-│   └── workflows/          # CI/CD pipelines
-│       ├── rust-ci.yml     # Rust testing & builds
-│       └── release.yml     # Release automation
-├── crates/                 # Rust workspace
-│   ├── temporal-compare/
-│   │   ├── src/
-│   │   │   └── lib.rs      # Main library code
-│   │   ├── tests/          # Integration tests
-│   │   ├── benches/        # Benchmarks
-│   │   └── Cargo.toml      # Crate manifest
-│   ├── nanosecond-scheduler/
-│   ├── temporal-attractor-studio/
-│   ├── temporal-neural-solver/
-│   ├── strange-loop/
-│   └── quic-multistream/
-│       ├── src/
-│       │   ├── lib.rs      # Common code
-│       │   ├── native.rs   # Native implementation
-│       │   └── wasm.rs     # WASM implementation
-│       └── Cargo.toml
-├── npm/
-│   ├── src/
-│   │   ├── agent.ts           # Lean agentic learning
-│   │   ├── dashboard.ts       # Real-time dashboard
-│   │   ├── openai-realtime.ts # OpenAI integration
-│   │   ├── restream-integration.ts
-│   │   ├── streaming.ts       # WebSocket/SSE
-│   │   └── mcp-server.ts      # MCP protocol
-│   ├── __tests__/             # Jest tests
-│   ├── examples/              # Demo applications
-│   ├── scripts/               # Utility scripts
-│   └── package.json
-├── wasm-bindings/          # WASM compilation target
-├── examples/               # Rust examples
-├── plans/                  # Documentation
-├── Cargo.toml              # Workspace manifest
-└── README.md              # This file
-```
+The xtask crate (`cargo xtask --help`) replaces hand-rolled shell scripts — ADR-0037.
 
 ---
 
-## 🔄 CI/CD
+## Project Conventions
 
-MidStream uses GitHub Actions for comprehensive CI/CD.
-
-### Workflows
-
-#### 1. Rust CI/CD (`.github/workflows/rust-ci.yml`)
-
-**Triggers:**
-- Push to `main`, `develop`
-- Pull requests to `main`
-- Manual dispatch
-
-**Jobs:**
-- **Format Check**: `cargo fmt --check`
-- **Clippy Lints**: `cargo clippy -- -D warnings`
-- **Test Matrix**:
-  - OS: Ubuntu, macOS, Windows
-  - Rust: stable, nightly
-  - 3×2 = 6 combinations
-- **Build Crates**: Individual crate builds
-- **WASM Build**: WebAssembly compilation
-- **Benchmarks**: Performance regression detection
-- **Documentation**: `cargo doc` with deployment
-- **Security Audit**: `cargo audit`
-- **Code Coverage**: Codecov integration
-
-**Build Matrix:**
-```yaml
-strategy:
-  matrix:
-    os: [ubuntu-latest, macos-latest, windows-latest]
-    rust: [stable, nightly]
-```
-
-#### 2. Release Workflow (`.github/workflows/release.yml`)
-
-**Triggers:**
-- Tags matching `v*.*.*`
-- Manual dispatch with version input
-
-**Jobs:**
-- **Create Release**: GitHub release with changelog
-- **Build Release Binaries**:
-  - Linux (x86_64, ARM64)
-  - macOS (Intel, Apple Silicon)
-  - Windows (x64)
-- **Publish Crates**: Automated crates.io publishing
-- **Update Documentation**: Versioned docs deployment
-
-**Release Process:**
-```bash
-# Automatic on tag push
-git tag -a v0.2.0 -m "Release v0.2.0"
-git push origin v0.2.0
-
-# Or manual trigger via GitHub Actions UI
-```
-
-### CI Performance
-
-| Job | Average Duration | Success Rate |
-|-----|-----------------|--------------|
-| Format Check | ~30s | 100% |
-| Clippy | ~3min | 98% |
-| Tests (Ubuntu/stable) | ~8min | 99% |
-| Tests (macOS/stable) | ~10min | 97% |
-| Tests (Windows/stable) | ~12min | 95% |
-| WASM Build | ~5min | 99% |
-| Benchmarks | ~15min | 98% |
-| Documentation | ~6min | 100% |
-
-### Quality Gates
-
-Pull requests must pass:
-- ✅ All format checks
-- ✅ All clippy lints (zero warnings)
-- ✅ All tests on all platforms
-- ✅ Security audit (no vulnerabilities)
-- ✅ Documentation builds successfully
-- ✅ WASM compilation succeeds
+- **Modular Cargo workspace.** One root, every member is in `crates/` or a top-level directory — ADR-0001.
+- **Off-by-default features, prefixed by domain** (`backend-`, `provider-`, `wasm-`, `insecure-`) — ADR-0025.
+- **`thiserror` for libraries, `anyhow` for binaries** — ADR-0018.
+- **Workspace-wide lints.** `dbg!`, `todo!()`, `unimplemented!()`, `mem::forget` are all `deny` — ADR-0034.
+- **Cargo.lock is committed.** Standard for binary-shipping workspaces; required for `cargo audit` and `--locked` MSRV checks.
+- **Released via `release.yml`.** Tag `vX.Y.Z`, the workflow handles `cargo set-version`, dependency-DAG publish, and the GitHub release — ADR-0017.
 
 ---
 
-## 🧪 Testing
+## Contributing
 
-Comprehensive test coverage across all components.
+PRs welcome. The bar:
 
-### Test Statistics
+1. Every change references an ADR (or proposes a new one if it's a real decision).
+2. New code has property tests where the surface is parseable / generative; unit tests otherwise.
+3. `cargo clippy` clean and `cargo fmt` applied — both are CI gates.
+4. Security-sensitive changes (TLS, network, deserialization) get an explicit ADR-0011 / ADR-0015 review.
 
-```
-Total Tests: 139 passing
-
-TypeScript/npm:
-  Test Suites: 5 suites
-  Tests: 104 total
-    ✅ Dashboard: 26/26 (100%)
-    ✅ OpenAI Realtime: 26/26 (100%)
-    ✅ QUIC Integration: 37/37 (100%)
-    ✅ Restream: 15/15 (100%)
-    ✅ Agent: Pass
-
-Rust Workspace:
-  Crates: 6 crates
-  Tests: 35+ total
-    ✅ temporal-compare: 8/8 (100%)
-    ✅ nanosecond-scheduler: 6/6 (100%)
-    ✅ temporal-attractor-studio: 6/6 (100%)
-    ✅ temporal-neural-solver: 7/7 (100%)
-    ✅ strange-loop: 8/8 (100%)
-    ✅ quic-multistream: (native + WASM tests)
-
-Lines of Code: 3,171+ production Rust code
-Test Coverage: >85% (Rust), >90% (TypeScript new code)
-```
-
-### Running Tests
-
-```bash
-# All TypeScript tests
-cd npm
-npm test
-
-# With coverage report
-npm run test:coverage
-
-# Watch mode for development
-npm run test:watch
-
-# Specific test file
-npm test -- openai-realtime.test.ts
-
-# All Rust tests
-cargo test --workspace --all-features
-
-# Specific crate
-cargo test -p temporal-compare
-
-# With output
-cargo test -- --nocapture
-
-# Integration tests only
-cargo test --test '*'
-
-# Doc tests
-cargo test --doc
-```
-
-### Test Types
-
-#### 1. Unit Tests
-```rust
-// Example from temporal-compare
-#[test]
-fn test_dtw_distance() {
-    let seq1 = create_test_sequence(&[1, 2, 3]);
-    let seq2 = create_test_sequence(&[1, 2, 4]);
-    let comparator = SequenceComparator::new();
-    let distance = comparator.dtw_distance(&seq1, &seq2).unwrap();
-    assert!(distance > 0.0);
-}
-```
-
-#### 2. Integration Tests
-```typescript
-// Example from OpenAI Realtime
-describe('OpenAIRealtimeClient', () => {
-  it('should connect and handle responses', async () => {
-    const client = new OpenAIRealtimeClient({ apiKey: 'test' });
-    await client.connect();
-    expect(client.isConnected()).toBe(true);
-  });
-});
-```
-
-#### 3. Simulation Tests
-```rust
-// Example from lean agentic benchmarks
-#[test]
-fn test_high_frequency_streaming() {
-    let agent = create_test_agent();
-    let messages: Vec<_> = (0..1000).map(|i| format!("Message {}", i)).collect();
-
-    for msg in messages {
-        agent.process_message(&msg, 5).unwrap();
-    }
-
-    let metrics = agent.get_metrics();
-    assert!(metrics.throughput > 50.0); // >50 msg/s
-}
-```
-
-#### 4. Property-Based Tests
-```rust
-use proptest::prelude::*;
-
-proptest! {
-    #[test]
-    fn dtw_distance_symmetric(a in any::<Vec<i32>>(), b in any::<Vec<i32>>()) {
-        let d1 = dtw_distance(&a, &b);
-        let d2 = dtw_distance(&b, &a);
-        assert!((d1 - d2).abs() < 1e-10);
-    }
-}
-```
-
-### Security Testing
-
-```bash
-# Run security audit
-npx ts-node scripts/security-check.ts
-
-# Results:
-# ✅ No hardcoded credentials
-# ✅ HTTPS/WSS enforcement
-# ✅ Input validation present
-# ✅ Rate limiting configured
-# ✅ Secure error handling
-# ✅ No sensitive data logging
-# ✅ CORS properly configured
-# ✅ Environment variable usage
-# ✅ No eval() or unsafe code
-# ✅ Dependencies up to date
-
-# Overall Score: A+ (10/10 checks passed)
-```
+See [`CONTRIBUTING.md`](CONTRIBUTING.md), [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md), and [`SECURITY.md`](SECURITY.md) — all ratified under ADR-0039.
 
 ---
 
-## 🎯 Use Cases
+## Support
 
-### Real-Time Customer Support
-```typescript
-const dashboard = new MidStreamDashboard();
-const agent = dashboard.getAgent();
+| Resource | Link |
+|---|---|
+| Issues & bugs | [GitHub Issues](https://github.com/ruvnet/midstream/issues) |
+| Architecture decisions | [`docs/adr/`](docs/adr/README.md) |
+| Security disclosures | [`SECURITY.md`](SECURITY.md) |
+| Author | [ruv.io](https://ruv.io) · [@ruvnet](https://github.com/ruvnet) |
 
-// Analyze conversation patterns
-agent.processMessage('I need help with my order');
-const patterns = agent.detectPattern(history, ['greeting', 'problem', 'solution']);
-```
+## License
 
-### Video Stream Analysis
-```typescript
-const client = new RestreamClient({
-  enableObjectDetection: true,
-  enableTranscription: true
-});
-
-client.on('objects_detected', (data) => {
-  console.log(`Detected: ${data.objects.length} objects`);
-});
-```
-
-### Voice Agent with OpenAI
-```typescript
-const openai = new OpenAIRealtimeClient({ apiKey });
-const dashboard = new MidStreamDashboard();
-
-openai.on('response.audio.delta', (audio) => {
-  dashboard.processStream('openai', Buffer.from(audio, 'base64'), 'audio');
-});
-```
-
-### Low-Latency Multiplexed Streaming with QUIC
-```typescript
-const connection = await connectQuic('localhost', 4433);
-
-// High-priority video stream
-const videoStream = await connection.openBiStream({ priority: 10 });
-videoStream.write(videoFrame);
-
-// Medium-priority audio stream
-const audioStream = await connection.openBiStream({ priority: 9 });
-audioStream.write(audioChunk);
-
-// Low-priority telemetry
-const telemetryStream = await connection.openUniStream({ priority: 1 });
-telemetryStream.write(stats);
-
-// Get connection statistics
-const stats = connection.getStats();
-console.log(`RTT: ${stats.rtt}ms, Throughput: ${stats.bytesSent} bytes`);
-```
-
----
-
-## 🔐 Security
-
-### Security Features
-- ✅ Environment variable management
-- ✅ No hardcoded credentials
-- ✅ HTTPS/WSS enforcement
-- ✅ Input validation
-- ✅ Rate limiting
-- ✅ Error handling
-- ✅ Secure logging
-- ✅ CORS configuration
-
-### Security Audit Results
-```
-Critical: 0
-High: 0
-Medium: 0
-Low: 0
-
-Overall Score: A+ (100%)
-Status: Production Ready
-```
-
----
-
-## 📊 Performance
-
-### Benchmarks
-```
-Dashboard Refresh: 100ms (configurable)
-Message Processing: <10ms average
-Stream Processing: <5ms per chunk
-Memory Usage: <50MB baseline
-CPU Usage: <5% idle, <15% active
-Throughput: 1000+ messages/sec
-```
-
-### Optimization Features
-- Configurable buffer sizes
-- Automatic memory management
-- Event-driven architecture
-- Non-blocking I/O
-- Connection pooling
-- Intelligent caching
-
----
-
-## 🛠️ Development
-
-### Project Structure
-```
-midstream/
-├── npm/                      # Node.js/TypeScript packages
-│   ├── src/
-│   │   ├── agent.ts         # Lean Agentic learning
-│   │   ├── dashboard.ts     # Real-time dashboard
-│   │   ├── restream-integration.ts  # Video streaming
-│   │   ├── openai-realtime.ts      # OpenAI integration
-│   │   ├── streaming.ts     # WebSocket/SSE
-│   │   └── mcp-server.ts    # MCP protocol
-│   ├── examples/            # Demo applications
-│   ├── scripts/             # Utility scripts
-│   └── __tests__/           # Test suites
-├── src/                     # Rust core engine
-│   ├── lean_agentic/        # Lean agentic system
-│   ├── bin/                 # Binaries
-│   └── tests/               # Rust tests
-├── wasm-bindings/           # WASM bindings
-├── hyprstream-main/         # Streaming engine
-└── docs/                    # Documentation
-```
-
-### Building from Source
-
-```bash
-# Build TypeScript
-cd npm
-npm run build:ts
-
-# Build Rust (when network available)
-cd ..
-cargo build --release
-
-# Build WASM
-cd wasm-bindings
-wasm-pack build --target nodejs
-```
-
----
-
-## 🤝 Contributing
-
-We welcome contributions from the community! MidStream is an open-source project that thrives on collaboration.
-
-### How to Contribute
-
-1. **Fork the Repository**
-   ```bash
-   gh repo fork ruvnet/midstream
-   cd midstream
-   ```
-
-2. **Create a Feature Branch**
-   ```bash
-   git checkout -b feature/amazing-feature
-   ```
-
-3. **Make Your Changes**
-   - Write clean, documented code
-   - Follow existing code style
-   - Add tests for new features
-   - Update documentation
-
-4. **Test Your Changes**
-   ```bash
-   # Run all tests
-   cargo test --workspace
-   cd npm && npm test
-
-   # Check formatting
-   cargo fmt --check
-   npm run lint
-
-   # Run security audit
-   cargo audit
-   npx ts-node scripts/security-check.ts
-   ```
-
-5. **Commit Your Changes**
-   ```bash
-   git add .
-   git commit -m "Add amazing feature"
-   ```
-
-6. **Push and Create PR**
-   ```bash
-   git push origin feature/amazing-feature
-   gh pr create --title "Add amazing feature" --body "Description of changes"
-   ```
-
-### Contribution Guidelines
-
-**Code Style:**
-- Rust: Follow `rustfmt` defaults
-- TypeScript: ESLint + Prettier configuration
-- Maximum line length: 100 characters
-- Use meaningful variable names
-- Add inline comments for complex logic
-
-**Testing:**
-- Write tests for all new features
-- Maintain >85% test coverage
-- Include both unit and integration tests
-- Add benchmarks for performance-critical code
-
-**Documentation:**
-- Update README if adding major features
-- Add doc comments to public APIs
-- Include usage examples
-- Update CHANGELOG.md
-
-**Commit Messages:**
-```
-<type>(<scope>): <subject>
-
-<body>
-
-<footer>
-```
-
-Examples:
-- `feat(quic): add stream prioritization`
-- `fix(dashboard): resolve memory leak in update loop`
-- `docs(readme): add WASM integration examples`
-- `test(temporal): add property-based tests for DTW`
-
-### Areas We Need Help
-
-**High Priority:**
-- 📝 Documentation and tutorials
-- 🧪 Additional test coverage
-- 🌍 Internationalization (i18n)
-- 🎨 Dashboard UI improvements
-- 📱 Mobile SDK development
-
-**Medium Priority:**
-- 🔌 Additional LLM provider integrations
-- 📊 Enhanced visualization options
-- 🚀 Performance optimizations
-- 🐛 Bug fixes and stability improvements
-
-**Low Priority:**
-- 🎯 Example applications
-- 📚 Blog posts and articles
-- 🎓 Educational content
-- 🛠️ Developer tooling
-
-### Code of Conduct
-
-We are committed to providing a welcoming and inclusive environment. All contributors must:
-- Be respectful and professional
-- Welcome newcomers and help them get started
-- Provide constructive feedback
-- Focus on what is best for the community
-- Show empathy towards other community members
-
-### Getting Help
-
-- **Questions**: Open a [GitHub Discussion](https://github.com/ruvnet/midstream/discussions)
-- **Bugs**: Report via [GitHub Issues](https://github.com/ruvnet/midstream/issues)
-- **Security**: Email security@midstream.dev (do not file public issues)
-- **Chat**: Join our community Discord (link in repository)
-
----
-
-## 📄 License
-
-**Apache License 2.0**
-
-```
-Copyright 2025 rUv and contributors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-```
-
-### Why Apache 2.0?
-
-Apache 2.0 is a permissive license that:
-- ✅ Allows commercial use
-- ✅ Permits modification
-- ✅ Enables distribution
-- ✅ Provides patent grant
-- ✅ Requires attribution
-
-See the full [LICENSE](LICENSE) file for details.
-
-### Third-Party Licenses
-
-MidStream uses the following open-source dependencies:
-
-**Rust Ecosystem:**
-- tokio (MIT) - Async runtime
-- serde (MIT/Apache-2.0) - Serialization framework
-- quinn (MIT/Apache-2.0) - QUIC implementation
-- nalgebra (Apache-2.0) - Linear algebra
-- ndarray (MIT/Apache-2.0) - N-dimensional arrays
-
-**JavaScript Ecosystem:**
-- @modelcontextprotocol/sdk (MIT) - MCP protocol
-- ws (MIT) - WebSocket implementation
-- commander (MIT) - CLI framework
-- chalk (MIT) - Terminal styling
-
-Full dependency list available in `Cargo.lock` and `package-lock.json`.
-
----
-
-## 🙏 Acknowledgments
-
-MidStream stands on the shoulders of giants. We're grateful to:
-
-### Core Technologies
-- **[Rust Language](https://www.rust-lang.org/)** - For providing a safe, fast, and concurrent foundation
-- **[Tokio](https://tokio.rs/)** - For the excellent async runtime that powers our concurrency
-- **[Quinn](https://github.com/quinn-rs/quinn)** - For the robust QUIC implementation
-- **[WebAssembly](https://webassembly.org/)** - For enabling browser deployment with native performance
-
-### Inspirations
-- **[HyprStream](https://github.com/hyprstream)** - Foundational concepts in real-time stream processing
-- **[OpenAI Realtime API](https://platform.openai.com/docs/api-reference/realtime)** - Pioneering real-time LLM interactions
-- **[WebRTC](https://webrtc.org/)** - Standards for real-time communication
-
-### Communities
-- **Rust Community** - For incredible tooling, documentation, and support
-- **Node.js Community** - For the vibrant JavaScript ecosystem
-- **WebAssembly Community** - For pushing the boundaries of web performance
-- **Academic Researchers** - For advancing the fields of dynamical systems, temporal logic, and meta-learning
-
-### Special Thanks
-- All our [contributors](https://github.com/ruvnet/midstream/graphs/contributors)
-- Early adopters and beta testers
-- Everyone who reported bugs and provided feedback
-
----
-
-## 📞 Support & Resources
-
-### Documentation
-- **[Complete Documentation](docs/)** - Full API reference and guides
-- **[Dashboard Guide](plans/DASHBOARD_README.md)** - Real-time monitoring setup
-- **[WASM Guide](plans/WASM_PERFORMANCE_GUIDE.md)** - WebAssembly deployment
-- **[Benchmarks](plans/BENCHMARKS_AND_OPTIMIZATIONS.md)** - Performance analysis
-- **[Examples](npm/examples/)** - Working code examples
-
-### Getting Help
-
-**For Questions:**
-- 💬 [GitHub Discussions](https://github.com/ruvnet/midstream/discussions) - Community Q&A
-- 📖 [Documentation](docs/) - Comprehensive guides
-- 💡 [Stack Overflow](https://stackoverflow.com/questions/tagged/midstream) - Tag: `midstream`
-
-**For Bugs:**
-- 🐛 [GitHub Issues](https://github.com/ruvnet/midstream/issues) - Bug reports
-- 🔍 [Search existing issues](https://github.com/ruvnet/midstream/issues?q=is%3Aissue) first
-
-**For Security:**
-- 🔒 Email: security@midstream.dev (do not file public issues)
-- 🛡️ See our [Security Policy](SECURITY.md)
-- 🔐 Run: `npx ts-node scripts/security-check.ts`
-
-**For Contributions:**
-- 🤝 See [Contributing Guidelines](#-contributing)
-- 📝 [Code of Conduct](CODE_OF_CONDUCT.md)
-- 🎯 [Good First Issues](https://github.com/ruvnet/midstream/labels/good%20first%20issue)
-
-### Links
-- **Homepage**: https://midstream.dev (coming soon)
-- **GitHub**: https://github.com/ruvnet/midstream
-- **npm Package**: https://www.npmjs.com/package/midstream-cli
-- **crates.io**: https://crates.io/crates/midstream (coming soon)
-- **Documentation**: https://docs.midstream.dev (coming soon)
-
----
-
-## 🌟 Highlights & Features
-
-### What Makes MidStream Unique
-
-1. **🦀 Production-Grade Published Crates**
-   - **5 crates published on crates.io** - Ready to use in any Rust project
-   - **1 workspace crate** (quic-multistream) - Available via git
-   - 3,171+ lines of production Rust code
-   - 139 passing tests with >85% coverage
-   - Native and WASM support
-   - Zero-cost abstractions
-   - **Easy installation**: Just add to Cargo.toml!
-
-2. **⚡ Ultra-Low Latency**
-   - <50ns scheduling latency
-   - <1ms message processing
-   - 0-RTT QUIC connections
-   - 1M+ tasks/second throughput
-
-3. **🧠 Advanced AI Features**
-   - Lean theorem proving for verified reasoning
-   - Meta-learning with experience replay
-   - Temporal pattern detection
-   - Dynamical systems analysis
-
-4. **🌐 Universal Deployment**
-   - Native: Linux, macOS, Windows (x64, ARM64)
-   - WASM: Browser, Node.js, Edge
-   - 65KB compressed binary
-   - WebTransport support
-
-5. **🔐 Production Security**
-   - 10/10 security audit score
-   - Zero vulnerabilities
-   - HTTPS/WSS enforcement
-   - Comprehensive input validation
-
-6. **🎥 Multi-Modal Streaming**
-   - QUIC/HTTP3 multiplexing
-   - WebRTC peer-to-peer
-   - RTMP/HLS support
-   - Text, audio, video
-
-7. **📊 Real-Time Analytics**
-   - Live dashboard with console UI
-   - Temporal attractor visualization
-   - Pattern detection
-   - Lyapunov exponents
-
-### Key Performance Metrics
-
-| Metric | Value | Benchmark |
-|--------|-------|-----------|
-| **Scheduling Latency** | 46ns (p50) | 100ns target ✅ |
-| **Message Processing** | 10ms (avg) | 20ms target ✅ |
-| **QUIC Throughput** | 4.2 Gbps | Line-rate ✅ |
-| **WASM Binary Size** | 65KB | 100KB target ✅ |
-| **Test Coverage** | >85% | 80% target ✅ |
-| **Security Score** | A+ (10/10) | Production ✅ |
-
-### Platform Support Matrix
-
-| Platform | Native | WASM | Status |
-|----------|--------|------|--------|
-| Linux x86_64 | ✅ | ✅ | Full |
-| Linux ARM64 | ✅ | ✅ | Full |
-| macOS Intel | ✅ | ✅ | Full |
-| macOS Apple Silicon | ✅ | ✅ | Full |
-| Windows x64 | ✅ | ✅ | Full |
-| Chrome/Edge | N/A | ✅ | WebTransport |
-| Node.js 18+ | ✅ | ✅ | Full |
-| Deno | ⚠️ | ✅ | Experimental |
-| Bun | ⚠️ | ⚠️ | Experimental |
-
-### Recent Updates
-
-**v0.1.0** - October 2025
-
-**📦 Five Crates Published on crates.io!**
-
-All core MidStream crates are now **publicly available** on [crates.io](https://crates.io/):
-
-- ✅ **[temporal-compare](https://crates.io/crates/temporal-compare)** v0.1 - Pattern matching with DTW, LCS, edit distance
-- ✅ **[nanosecond-scheduler](https://crates.io/crates/nanosecond-scheduler)** v0.1 - Ultra-low-latency real-time scheduling
-- ✅ **[temporal-attractor-studio](https://crates.io/crates/temporal-attractor-studio)** v0.1 - Dynamical systems & Lyapunov analysis
-- ✅ **[temporal-neural-solver](https://crates.io/crates/temporal-neural-solver)** v0.1 - LTL verification with neural reasoning
-- ✅ **[strange-loop](https://crates.io/crates/strange-loop)** v0.1 - Meta-learning & self-referential systems
-
-**Workspace Crate** (available via git):
-- ⚠️ **quic-multistream** - QUIC/HTTP3 transport (native + WASM) - *Publication planned*
-
-**Installation is now as simple as:**
-```toml
-[dependencies]
-temporal-compare = "0.1"
-nanosecond-scheduler = "0.1"
-temporal-attractor-studio = "0.1"
-temporal-neural-solver = "0.1"
-strange-loop = "0.1"
-```
-
-**Rust Workspace** (6 crates, 3,171 LOC, 35 tests):
-
-**TypeScript/Node.js** (104 tests):
-- ✅ **Real-time Dashboard**: Console UI with live metrics
-- ✅ **OpenAI Realtime**: Full API integration (26/26 tests)
-- ✅ **QUIC Integration**: Multiplexed streaming (37/37 tests)
-- ✅ **Restream**: RTMP/WebRTC/HLS framework (15/15 tests)
-- ✅ **Security Audit**: Automated checking (10/10 passed)
-
-**Infrastructure**:
-- ✅ **GitHub Actions CI/CD**: 10 workflows, 6-platform testing
-- ✅ **Release Automation**: Multi-architecture binary builds
-- ✅ **Documentation**: 2000+ lines comprehensive guides
-- ✅ **Code Quality**: Formatting, linting, security audits
-
-### Roadmap
-
-**v0.2.0** (Q1 2025)
-- 🔄 Enhanced WASM optimization
-- 🔄 Additional LLM provider integrations
-- 🔄 Mobile SDK (iOS/Android)
-- 🔄 Performance profiling tools
-- 🔄 Enhanced documentation and tutorials
-
-**v0.3.0** (Q2 2025)
-- 🔜 Distributed deployment support
-- 🔜 Enhanced visualization dashboard
-- 🔜 Plugin system for extensions
-- 🔜 Cloud-native deployment guides
-- 🔜 Kubernetes operator
-
-**Future**
-- 💡 Real-time collaborative features
-- 💡 Advanced ML model integration
-- 💡 Edge computing optimizations
-- 💡 Enterprise support options
-
----
-
-## 🏆 Awards & Recognition
-
-- 🌟 **GitHub**: 100+ stars
-- 🚀 **Early Adopters**: 50+ projects using MidStream
-- 📊 **Performance**: Top 1% for Rust streaming libraries
-- 🔐 **Security**: A+ rating, zero vulnerabilities
-
----
-
-**Created by rUv** 🚀
-
-*Real-time introspection for the AI age*
-
----
-
-<div align="center">
-
-**[⬆ Back to Top](#midstream)**
-
-Made with ❤️ using [Rust](https://www.rust-lang.org/) and [TypeScript](https://www.typescriptlang.org/)
-
-**[Website](https://midstream.dev)** • **[Documentation](https://docs.midstream.dev)** • **[GitHub](https://github.com/ruvnet/midstream)** • **[npm](https://www.npmjs.com/package/midstream-cli)**
-
-</div>
+Dual-licensed under **MIT OR Apache-2.0** — pick whichever is more convenient. The same dual licence applies to every workspace member, every WASM artifact, and every npm package. See [`LICENSE-MIT`](LICENSE-MIT) and [`LICENSE-APACHE`](LICENSE-APACHE). ADR-0036 explains why.


### PR DESCRIPTION
## Summary

The previous README was **2,223 lines** of feature lists, version matrices, integration examples, and historical content that mostly duplicated \`docs/\` — it had grown into a small website rather than an entry point.

Rewrite as a **200-line top-of-funnel**:
- One-line elevator pitch
- A *Why* paragraph and a *What it does* ASCII diagram
- Three install paths (one crate / full workspace / WASM)
- A capability table with emoji-tagged rows
- Collapsible \`<details>\` blocks for the crate matrix, npm packages, WASM, and the architecture diagram
- A four-doc *Documentation* table pointing at \`docs/{ARCHITECTURE,GETTING_STARTED,BENCHMARKS,SECURITY}.md\`
- A single *Support* table at the bottom

Structure borrowed from [\`ruvnet/ruflo\`'s README](https://github.com/ruvnet/ruflo/blob/main/README.md) (centered badge cluster, *Why X* / *What X Does*, capability table, collapsible details, four-doc index). Content is midstream-specific: the 6 published Rust libs, inflight-analysis story, ADR references, perf numbers from \`docs/BENCHMARKS.md\`, dev workflow matching the current CI gates (incl. \`--exclude midstream\` while ADR-0005's lean_agentic retirement is in flight).

## Test plan

- [x] No code or workflow changes — README-only diff
- [x] Markdown previewed locally; tables and \`<details>\` blocks render correctly
- [ ] CI on this PR confirms nothing else regressed

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)