### PR TITLE
fix(release): exclude midstream from update-docs cargo doc step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,7 +248,11 @@ jobs:
           shared-key: "docs-release"
 
       - name: Build documentation
-        run: cargo doc --workspace --all-features --no-deps
+        # Same midstream/hyprstream exclusion as rust-ci.yml's docs +
+        # release.yml's verify step: `--all-features` enables the
+        # off-by-default `lean-agentic` feature, which hits 27 errors
+        # in src/lean_agentic/. ADR-0005 deprecates that module.
+        run: cargo doc --workspace --exclude midstream --exclude hyprstream --all-features --no-deps
 
       - name: Add version badge to docs
         run: |


### PR DESCRIPTION
## Summary

Same root cause as #73 (rust-ci.yml docs job) and #75 (release.yml build-release): \`cargo doc --workspace --all-features\` enables the off-by-default \`lean-agentic\` feature on the midstream root crate, which hits 27 unresolved-import errors in \`src/lean_agentic/\`.

The v0.2.1 release run's \`Update Documentation\` job failed for this reason even though \`publish-crates\` succeeded — **the 6 libs are live on crates.io at 0.2.1**, but the doc deploy to gh-pages didn't run.

Add \`--exclude midstream --exclude hyprstream\` to the \`Build documentation\` step. Future releases will get the doc deploy back.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)