### PR TITLE
feat: split realtime reflex control from reasoning

### DIFF
--- a/.github/workflows/reflex-dependency-repair.yml
+++ b/.github/workflows/reflex-dependency-repair.yml
@@ -1,0 +1,74 @@
+name: Reflex dependency repair evidence
+
+on:
+  pull_request:
+    branches: [main]
+    paths: ['.github/workflows/reflex-dependency-repair.yml']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  repair-evidence:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0
+        with:
+          toolchain: 1.88.0
+          components: clippy
+      - name: Install pinned audit tool
+        run: cargo install cargo-audit --version 0.22.2 --locked
+      - name: Record original dependency evidence
+        run: |
+          mkdir -p /tmp/reflex-repair
+          git rev-parse HEAD > /tmp/reflex-repair/source-commit.txt
+          rustc --version --verbose > /tmp/reflex-repair/compiler.txt
+          set +e
+          cargo audit --json > /tmp/reflex-repair/audit-before.json
+          status=$?
+          set -e
+          echo "$status" > /tmp/reflex-repair/audit-before-exit.txt
+      - name: Prepare narrowly scoped dependency candidate
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+          for name in ['Cargo.toml', 'crates/temporal-compare/Cargo.toml']:
+              path = Path(name)
+              text = path.read_text()
+              assert text.count('lru = "0.16"') == 1, name
+              path.write_text(text.replace('lru = "0.16"', 'lru = "0.18.2"'))
+          PY
+          cargo update -p lru --precise 0.18.2
+          cargo update -p crossbeam-epoch --precise 0.9.20
+          cargo update -p h2 --precise 0.4.16
+          cargo update -p quinn-proto --precise 0.11.15
+          cargo update -p anyhow --precise 1.0.104
+      - name: Audit actual candidate lockfile
+        run: cargo audit --json > /tmp/reflex-repair/audit-after.json
+      - name: Check locked workspace on minimum Rust
+        run: cargo check --workspace --locked
+      - name: Test locked workspace libraries and integrations
+        run: cargo test --workspace --lib --tests --locked
+      - name: Strict root library lint
+        run: cargo clippy -p midstream --no-default-features --lib --locked -- -D warnings
+      - name: Retain exact proposed files and patch
+        run: |
+          git diff --check
+          git diff -- Cargo.toml Cargo.lock crates/temporal-compare/Cargo.toml > /tmp/reflex-repair/dependency-repair.patch
+          cp Cargo.toml /tmp/reflex-repair/Cargo.toml
+          cp Cargo.lock /tmp/reflex-repair/Cargo.lock
+          cp crates/temporal-compare/Cargo.toml /tmp/reflex-repair/temporal-compare-Cargo.toml
+          sha256sum Cargo.toml Cargo.lock crates/temporal-compare/Cargo.toml > /tmp/reflex-repair/files.sha256
+      - name: Upload dependency evidence for review, never push it
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: reflex-dependency-repair
+          path: /tmp/reflex-repair/
+          retention-days: 14
+          if-no-files-found: error

--- a/.github/workflows/reflex-validation.yml
+++ b/.github/workflows/reflex-validation.yml
@@ -1,0 +1,41 @@
+name: Reflex validation
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/reflex.rs'
+      - 'src/lib.rs'
+      - 'benches/reflex_bench.rs'
+      - '.github/workflows/reflex-validation.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  reflex:
+    name: Reflex contract and root integration
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0
+        with:
+          components: rustfmt, clippy
+      - name: Record compiler
+        run: rustc --version --verbose
+      - name: Format check
+        run: rustfmt --edition 2021 --check src/reflex.rs
+      - name: Compile standalone contract tests
+        run: rustc --edition 2021 --test src/reflex.rs -o /tmp/reflex-tests
+      - name: Run standalone contract tests
+        run: /tmp/reflex-tests
+      - name: Check actual root library without retired features
+        run: cargo check -p midstream --no-default-features --lib --locked
+      - name: Test actual root reflex module
+        run: cargo test -p midstream --no-default-features --lib reflex --locked
+      - name: Lint actual root library
+        run: cargo clippy -p midstream --no-default-features --lib --locked -- -D warnings
+      - name: Compile existing Criterion benchmark
+        run: cargo bench -p midstream --bench reflex_bench --no-run --locked

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,10 @@ harness = false
 name = "quic_bench"
 harness = false
 
+[[bench]]
+name = "reflex_bench"
+harness = false
+
 [[example]]
 name = "openrouter"
 path = "examples/openrouter.rs"

--- a/benches/reflex_bench.rs
+++ b/benches/reflex_bench.rs
@@ -1,0 +1,34 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use midstream::{ReflexController, ReflexEvent, ReflexEventKind};
+
+fn reflex_controller_benchmark(c: &mut Criterion) {
+    c.bench_function("reflex_controller_1000_events", |b| {
+        b.iter(|| {
+            let mut controller = ReflexController::new(1024);
+            for sequence in 1..=1000_u64 {
+                let kind = match sequence % 10 {
+                    0 => ReflexEventKind::Interrupt,
+                    1 => ReflexEventKind::Backchannel,
+                    2 => ReflexEventKind::Cancel,
+                    _ => ReflexEventKind::Observation,
+                };
+                let receipt = controller.observe(
+                    ReflexEvent {
+                        sequence,
+                        at_micros: sequence * 100,
+                        kind,
+                    },
+                    4,
+                );
+                black_box(receipt);
+                if controller.queued() >= 1000 {
+                    black_box(controller.drain_for_reasoner());
+                }
+            }
+            black_box(controller.drain_for_reasoner());
+        });
+    });
+}
+
+criterion_group!(benches, reflex_controller_benchmark);
+criterion_main!(benches);

--- a/crates/quic-multistream/src/native.rs
+++ b/crates/quic-multistream/src/native.rs
@@ -47,7 +47,7 @@ impl QuicConnection {
 
         let client_config = ClientConfig::new(Arc::new(
             quinn::crypto::rustls::QuicClientConfig::try_from(crypto)
-                .map_err(|e| QuicError::TlsError(format!("{:?}", e)))?,
+                .map_err(|e| QuicError::TlsError(format!("{e:?}")))?,
         ));
 
         // Create endpoint bound to an ephemeral local port.
@@ -197,7 +197,7 @@ impl QuicStream {
     pub async fn finish(&mut self) -> Result<(), QuicError> {
         self.send
             .finish()
-            .map_err(|e| QuicError::StreamError(format!("Failed to finish stream: {:?}", e)))?;
+            .map_err(|e| QuicError::StreamError(format!("Failed to finish stream: {e:?}")))?;
         Ok(())
     }
 
@@ -237,7 +237,7 @@ impl QuicSendStream {
     pub async fn finish(&mut self) -> Result<(), QuicError> {
         self.send
             .finish()
-            .map_err(|e| QuicError::StreamError(format!("Failed to finish stream: {:?}", e)))?;
+            .map_err(|e| QuicError::StreamError(format!("Failed to finish stream: {e:?}")))?;
         Ok(())
     }
 }

--- a/crates/temporal-neural-solver/src/lib.rs
+++ b/crates/temporal-neural-solver/src/lib.rs
@@ -256,7 +256,7 @@ impl TemporalNeuralSolver {
 
         let satisfied = self.check_formula(formula, 0)?;
 
-        let formula_str = format!("{:?}", formula);
+        let formula_str = format!("{formula:?}");
 
         Ok(VerificationResult {
             satisfied,
@@ -317,8 +317,7 @@ impl TemporalNeuralSolver {
                         Ok(false)
                     }
                     _ => Err(TemporalError::ParseError(format!(
-                        "Invalid unary operator: {:?}",
-                        op
+                        "Invalid unary operator: {op:?}"
                     ))),
                 }
             }
@@ -347,8 +346,7 @@ impl TemporalNeuralSolver {
                         Ok(false)
                     }
                     _ => Err(TemporalError::ParseError(format!(
-                        "Invalid binary operator: {:?}",
-                        op
+                        "Invalid binary operator: {op:?}"
                     ))),
                 }
             }

--- a/docs/adr/0040-reflex-reasoning-split.md
+++ b/docs/adr/0040-reflex-reasoning-split.md
@@ -1,0 +1,56 @@
+# ADR 0040: Separate Realtime Reflex Control From Deliberative Reasoning
+
+Status: proposed
+
+Date: 2026-09-09
+
+Issue: #106
+
+## Context
+
+Realtime agents have two incompatible latency regimes. Interaction control such as interruption acknowledgement, backchannel, pause, and cancellation must react quickly. Planning, tool selection, and complex reasoning can take much longer. Running both through one deliberative loop increases interruption latency and wastes inference when work should have been cancelled earlier.
+
+## Decision
+
+Add a small MidStream reflex controller in front of the deliberative agent.
+
+The reflex controller may only acknowledge interaction, pause reasoning, request cancellation, and forward observations to the reasoner. It cannot invoke privileged tools, grant capabilities, mutate external state, or declare the task complete.
+
+Ruflo remains responsible for deliberative reasoning. RVM remains responsible for privileged external effects.
+
+## Invariants
+
+1. Every reflex receipt has `authority: none`.
+2. Event sequence numbers are monotonic. Stale events fail closed.
+3. Queues are bounded.
+4. Adjacent repeated interruptions are coalesced to avoid interrupt storms.
+5. Cancellation accounts for abandoned work rather than hiding it.
+6. The reasoner handoff preserves event order and cancellation provenance.
+7. Reflex processing cannot execute network, filesystem, tool, credential, or capability operations.
+
+## Benchmark
+
+Compare a monolithic controller and the split controller on matched event traces containing normal speech, interruptions, repeated interruptions, cancellation, delayed observations, stale events, queue pressure, and deliberative work of varying duration.
+
+Report acknowledgement latency, completion quality proxy, cancelled work units, wasted work, queue depth, stale drops, overflow, p50 and p99 reflex processing latency, and total model cost.
+
+## Promotion gate
+
+1. interruption acknowledgement latency improves by at least 40 percent
+2. task quality remains within 2 absolute percentage points
+3. wasted deliberative work after cancellation remains below 10 percent
+4. stale and out of order events never trigger state changing reflexes
+5. p99 reflex processing remains below the declared realtime budget
+6. no reflex receipt carries execution authority
+
+## Security
+
+Reflex events are untrusted observations. Even a valid interrupt or cancellation request does not grant external effect authority. RVM remains the only privileged enforcement boundary.
+
+## Rollback
+
+The module is additive. Removing `src/reflex.rs` and its export returns MidStream to the current monolithic path. No persisted state migration is introduced.
+
+## Cross stack
+
+MidStream owns reflex arbitration. Ruflo owns deliberation. MetaHarness independently benchmarks split versus monolithic behavior. RVM owns authority. Core Memory may retain receipts. Cognitum can use the split in voice, robotics, ambient, and realtime customer agent products.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,8 +79,8 @@ pub use midstream::{
     StreamProcessor, TimeWindow, ToolIntegration,
 };
 pub use reflex::{
-    ReasonerHandoff, ReflexAction, ReflexController, ReflexDisposition, ReflexEvent, ReflexEventKind,
-    ReflexReceipt,
+    ReasonerHandoff, ReflexAction, ReflexActions, ReflexController, ReflexDisposition, ReflexEvent,
+    ReflexEventKind, ReflexReceipt,
 };
 
 // Lean Agentic Learning System exports — gated behind the same feature.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@
 pub mod config;
 pub mod hypr_service;
 pub mod midstream;
+pub mod reflex;
 pub mod tests;
 
 // `lean_agentic` is the legacy in-tree subsystem that ADR-0005 retires.
@@ -76,6 +77,10 @@ pub use hypr_service::HyprServiceImpl;
 pub use midstream::{
     AggregateFunction, HyprService, Intent, LLMClient, LLMMessage, MetricRecord, Midstream,
     StreamProcessor, TimeWindow, ToolIntegration,
+};
+pub use reflex::{
+    ReasonerHandoff, ReflexAction, ReflexController, ReflexDisposition, ReflexEvent, ReflexEventKind,
+    ReflexReceipt,
 };
 
 // Lean Agentic Learning System exports — gated behind the same feature.

--- a/src/midstream.rs
+++ b/src/midstream.rs
@@ -196,7 +196,7 @@ impl Midstream {
 
         // Attempt to ingest metric and handle errors
         if let Err(e) = self.hypr_service.ingest_metric(metric.clone()).await {
-            return Err(format!("Failed to ingest metric: {}", e).into());
+            return Err(format!("Failed to ingest metric: {e}").into());
         }
 
         // Update internal metrics

--- a/src/reflex.rs
+++ b/src/reflex.rs
@@ -131,9 +131,8 @@ impl ReasonerHandoff {
             })
             .collect::<Vec<_>>()
             .join(",");
-        let latch = |value: Option<u64>| {
-            value.map_or_else(|| "null".to_string(), |v| format!("\"{v}\""))
-        };
+        let latch =
+            |value: Option<u64>| value.map_or_else(|| "null".to_string(), |v| format!("\"{v}\""));
         Ok(format!(
             "{{\"version\":1,\"authority\":\"none\",\"session_id\":\"{}\",\"latest_sequence\":\"{}\",\"queued_events\":[{}],\"interrupt_sequence\":{},\"cancel_sequence\":{},\"cancelled_work_units\":\"{}\",\"dropped_events\":\"{}\"}}",
             session_id, self.latest_sequence, events, latch(self.interrupt_sequence),
@@ -305,7 +304,8 @@ mod tests {
         let mut c = ReflexController::new(8);
         c.observe(event(1, ReflexEventKind::Interrupt), 0);
         assert_eq!(
-            c.observe(event(2, ReflexEventKind::Interrupt), 0).disposition,
+            c.observe(event(2, ReflexEventKind::Interrupt), 0)
+                .disposition,
             ReflexDisposition::Coalesced
         );
         let h = c.drain_for_reasoner();
@@ -350,7 +350,10 @@ mod tests {
         c.observe(event(2, ReflexEventKind::Cancel), 3);
         let h = c.drain_for_reasoner();
         assert_eq!(
-            h.queued_events.iter().map(|e| e.sequence).collect::<Vec<_>>(),
+            h.queued_events
+                .iter()
+                .map(|e| e.sequence)
+                .collect::<Vec<_>>(),
             vec![1, 2]
         );
         assert_eq!(h.authority, "none");
@@ -384,7 +387,8 @@ mod tests {
         c.observe(event(1, ReflexEventKind::Interrupt), 0);
         c.drain_for_reasoner();
         assert_eq!(
-            c.observe(event(2, ReflexEventKind::Interrupt), 0).disposition,
+            c.observe(event(2, ReflexEventKind::Interrupt), 0)
+                .disposition,
             ReflexDisposition::Accepted
         );
         assert_eq!(c.queued(), 1);

--- a/src/reflex.rs
+++ b/src/reflex.rs
@@ -1,0 +1,229 @@
+//! Realtime reflex control for two-speed agents.
+//!
+//! The reflex path can acknowledge, pause, cancel, and forward events, but it
+//! cannot authorize external effects. Privileged actions remain behind RVM and
+//! the deliberative reasoning path.
+
+use std::collections::VecDeque;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReflexEventKind {
+    Interrupt,
+    Backchannel,
+    Cancel,
+    Observation,
+    CommitBoundary,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReflexEvent {
+    pub sequence: u64,
+    pub at_micros: u64,
+    pub kind: ReflexEventKind,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReflexAction {
+    Acknowledge,
+    PauseReasoning,
+    RequestCancel,
+    ForwardToReasoner,
+    Noop,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReflexDisposition {
+    Accepted,
+    Stale,
+    Coalesced,
+    Overflow,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReflexReceipt {
+    pub sequence: u64,
+    pub disposition: ReflexDisposition,
+    pub actions: Vec<ReflexAction>,
+    pub authority: &'static str,
+    pub queued: usize,
+    pub cancelled_work_units: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReasonerHandoff {
+    pub latest_sequence: u64,
+    pub queued_events: Vec<ReflexEvent>,
+    pub cancelled_work_units: u64,
+    pub authority: &'static str,
+}
+
+#[derive(Clone, Debug)]
+pub struct ReflexController {
+    max_queue: usize,
+    latest_sequence: u64,
+    queue: VecDeque<ReflexEvent>,
+    cancelled_work_units: u64,
+    last_interrupt_sequence: Option<u64>,
+}
+
+impl ReflexController {
+    pub fn new(max_queue: usize) -> Self {
+        Self {
+            max_queue: max_queue.max(1),
+            latest_sequence: 0,
+            queue: VecDeque::new(),
+            cancelled_work_units: 0,
+            last_interrupt_sequence: None,
+        }
+    }
+
+    pub fn observe(&mut self, event: ReflexEvent, in_flight_work_units: u64) -> ReflexReceipt {
+        if event.sequence <= self.latest_sequence {
+            return self.receipt(event.sequence, ReflexDisposition::Stale, vec![ReflexAction::Noop]);
+        }
+
+        self.latest_sequence = event.sequence;
+
+        if event.kind == ReflexEventKind::Interrupt
+            && self
+                .last_interrupt_sequence
+                .is_some_and(|previous| event.sequence == previous + 1)
+        {
+            self.last_interrupt_sequence = Some(event.sequence);
+            return self.receipt(
+                event.sequence,
+                ReflexDisposition::Coalesced,
+                vec![ReflexAction::Acknowledge, ReflexAction::PauseReasoning],
+            );
+        }
+
+        if self.queue.len() >= self.max_queue {
+            return self.receipt(event.sequence, ReflexDisposition::Overflow, vec![ReflexAction::Noop]);
+        }
+
+        let actions = match event.kind {
+            ReflexEventKind::Interrupt => {
+                self.last_interrupt_sequence = Some(event.sequence);
+                vec![ReflexAction::Acknowledge, ReflexAction::PauseReasoning]
+            }
+            ReflexEventKind::Backchannel => vec![ReflexAction::Acknowledge],
+            ReflexEventKind::Cancel => {
+                self.cancelled_work_units = self
+                    .cancelled_work_units
+                    .saturating_add(in_flight_work_units);
+                vec![ReflexAction::Acknowledge, ReflexAction::RequestCancel]
+            }
+            ReflexEventKind::Observation | ReflexEventKind::CommitBoundary => {
+                vec![ReflexAction::ForwardToReasoner]
+            }
+        };
+
+        self.queue.push_back(event.clone());
+        self.receipt(event.sequence, ReflexDisposition::Accepted, actions)
+    }
+
+    pub fn drain_for_reasoner(&mut self) -> ReasonerHandoff {
+        let queued_events = self.queue.drain(..).collect();
+        ReasonerHandoff {
+            latest_sequence: self.latest_sequence,
+            queued_events,
+            cancelled_work_units: self.cancelled_work_units,
+            authority: "none",
+        }
+    }
+
+    pub fn queued(&self) -> usize {
+        self.queue.len()
+    }
+
+    fn receipt(
+        &self,
+        sequence: u64,
+        disposition: ReflexDisposition,
+        actions: Vec<ReflexAction>,
+    ) -> ReflexReceipt {
+        ReflexReceipt {
+            sequence,
+            disposition,
+            actions,
+            authority: "none",
+            queued: self.queue.len(),
+            cancelled_work_units: self.cancelled_work_units,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event(sequence: u64, kind: ReflexEventKind) -> ReflexEvent {
+        ReflexEvent {
+            sequence,
+            at_micros: sequence * 100,
+            kind,
+        }
+    }
+
+    #[test]
+    fn interrupt_acknowledges_without_authority() {
+        let mut controller = ReflexController::new(8);
+        let receipt = controller.observe(event(1, ReflexEventKind::Interrupt), 12);
+        assert_eq!(receipt.disposition, ReflexDisposition::Accepted);
+        assert_eq!(receipt.authority, "none");
+        assert_eq!(
+            receipt.actions,
+            vec![ReflexAction::Acknowledge, ReflexAction::PauseReasoning]
+        );
+    }
+
+    #[test]
+    fn stale_events_fail_closed() {
+        let mut controller = ReflexController::new(8);
+        controller.observe(event(2, ReflexEventKind::Observation), 0);
+        let stale = controller.observe(event(1, ReflexEventKind::Cancel), 50);
+        assert_eq!(stale.disposition, ReflexDisposition::Stale);
+        assert_eq!(stale.cancelled_work_units, 0);
+    }
+
+    #[test]
+    fn adjacent_interrupts_coalesce() {
+        let mut controller = ReflexController::new(8);
+        controller.observe(event(1, ReflexEventKind::Interrupt), 0);
+        let second = controller.observe(event(2, ReflexEventKind::Interrupt), 0);
+        assert_eq!(second.disposition, ReflexDisposition::Coalesced);
+        assert_eq!(controller.queued(), 1);
+    }
+
+    #[test]
+    fn cancellation_accounts_wasted_work() {
+        let mut controller = ReflexController::new(8);
+        let receipt = controller.observe(event(1, ReflexEventKind::Cancel), 7);
+        assert_eq!(receipt.cancelled_work_units, 7);
+        assert!(receipt.actions.contains(&ReflexAction::RequestCancel));
+    }
+
+    #[test]
+    fn queue_overflow_does_not_expand_state() {
+        let mut controller = ReflexController::new(1);
+        controller.observe(event(1, ReflexEventKind::Observation), 0);
+        let overflow = controller.observe(event(2, ReflexEventKind::Backchannel), 0);
+        assert_eq!(overflow.disposition, ReflexDisposition::Overflow);
+        assert_eq!(controller.queued(), 1);
+    }
+
+    #[test]
+    fn handoff_preserves_event_order_and_has_no_authority() {
+        let mut controller = ReflexController::new(8);
+        controller.observe(event(1, ReflexEventKind::Observation), 0);
+        controller.observe(event(2, ReflexEventKind::Cancel), 3);
+        let handoff = controller.drain_for_reasoner();
+        assert_eq!(handoff.authority, "none");
+        assert_eq!(handoff.cancelled_work_units, 3);
+        assert_eq!(
+            handoff.queued_events.iter().map(|e| e.sequence).collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+        assert_eq!(controller.queued(), 0);
+    }
+}

--- a/src/reflex.rs
+++ b/src/reflex.rs
@@ -32,6 +32,32 @@ pub enum ReflexAction {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ReflexActions {
+    pub first: ReflexAction,
+    pub second: Option<ReflexAction>,
+}
+
+impl ReflexActions {
+    const fn one(first: ReflexAction) -> Self {
+        Self {
+            first,
+            second: None,
+        }
+    }
+
+    const fn two(first: ReflexAction, second: ReflexAction) -> Self {
+        Self {
+            first,
+            second: Some(second),
+        }
+    }
+
+    pub fn contains(&self, action: ReflexAction) -> bool {
+        self.first == action || self.second == Some(action)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ReflexDisposition {
     Accepted,
     Stale,
@@ -43,7 +69,7 @@ pub enum ReflexDisposition {
 pub struct ReflexReceipt {
     pub sequence: u64,
     pub disposition: ReflexDisposition,
-    pub actions: Vec<ReflexAction>,
+    pub actions: ReflexActions,
     pub authority: &'static str,
     pub queued: usize,
     pub cancelled_work_units: u64,
@@ -79,7 +105,11 @@ impl ReflexController {
 
     pub fn observe(&mut self, event: ReflexEvent, in_flight_work_units: u64) -> ReflexReceipt {
         if event.sequence <= self.latest_sequence {
-            return self.receipt(event.sequence, ReflexDisposition::Stale, vec![ReflexAction::Noop]);
+            return self.receipt(
+                event.sequence,
+                ReflexDisposition::Stale,
+                ReflexActions::one(ReflexAction::Noop),
+            );
         }
 
         self.latest_sequence = event.sequence;
@@ -93,33 +123,38 @@ impl ReflexController {
             return self.receipt(
                 event.sequence,
                 ReflexDisposition::Coalesced,
-                vec![ReflexAction::Acknowledge, ReflexAction::PauseReasoning],
+                ReflexActions::two(ReflexAction::Acknowledge, ReflexAction::PauseReasoning),
             );
         }
 
         if self.queue.len() >= self.max_queue {
-            return self.receipt(event.sequence, ReflexDisposition::Overflow, vec![ReflexAction::Noop]);
+            return self.receipt(
+                event.sequence,
+                ReflexDisposition::Overflow,
+                ReflexActions::one(ReflexAction::Noop),
+            );
         }
 
         let actions = match event.kind {
             ReflexEventKind::Interrupt => {
                 self.last_interrupt_sequence = Some(event.sequence);
-                vec![ReflexAction::Acknowledge, ReflexAction::PauseReasoning]
+                ReflexActions::two(ReflexAction::Acknowledge, ReflexAction::PauseReasoning)
             }
-            ReflexEventKind::Backchannel => vec![ReflexAction::Acknowledge],
+            ReflexEventKind::Backchannel => ReflexActions::one(ReflexAction::Acknowledge),
             ReflexEventKind::Cancel => {
                 self.cancelled_work_units = self
                     .cancelled_work_units
                     .saturating_add(in_flight_work_units);
-                vec![ReflexAction::Acknowledge, ReflexAction::RequestCancel]
+                ReflexActions::two(ReflexAction::Acknowledge, ReflexAction::RequestCancel)
             }
             ReflexEventKind::Observation | ReflexEventKind::CommitBoundary => {
-                vec![ReflexAction::ForwardToReasoner]
+                ReflexActions::one(ReflexAction::ForwardToReasoner)
             }
         };
 
-        self.queue.push_back(event.clone());
-        self.receipt(event.sequence, ReflexDisposition::Accepted, actions)
+        let sequence = event.sequence;
+        self.queue.push_back(event);
+        self.receipt(sequence, ReflexDisposition::Accepted, actions)
     }
 
     pub fn drain_for_reasoner(&mut self) -> ReasonerHandoff {
@@ -140,7 +175,7 @@ impl ReflexController {
         &self,
         sequence: u64,
         disposition: ReflexDisposition,
-        actions: Vec<ReflexAction>,
+        actions: ReflexActions,
     ) -> ReflexReceipt {
         ReflexReceipt {
             sequence,
@@ -173,7 +208,7 @@ mod tests {
         assert_eq!(receipt.authority, "none");
         assert_eq!(
             receipt.actions,
-            vec![ReflexAction::Acknowledge, ReflexAction::PauseReasoning]
+            ReflexActions::two(ReflexAction::Acknowledge, ReflexAction::PauseReasoning)
         );
     }
 
@@ -200,7 +235,7 @@ mod tests {
         let mut controller = ReflexController::new(8);
         let receipt = controller.observe(event(1, ReflexEventKind::Cancel), 7);
         assert_eq!(receipt.cancelled_work_units, 7);
-        assert!(receipt.actions.contains(&ReflexAction::RequestCancel));
+        assert!(receipt.actions.contains(ReflexAction::RequestCancel));
     }
 
     #[test]
@@ -221,7 +256,11 @@ mod tests {
         assert_eq!(handoff.authority, "none");
         assert_eq!(handoff.cancelled_work_units, 3);
         assert_eq!(
-            handoff.queued_events.iter().map(|e| e.sequence).collect::<Vec<_>>(),
+            handoff
+                .queued_events
+                .iter()
+                .map(|event| event.sequence)
+                .collect::<Vec<_>>(),
             vec![1, 2]
         );
         assert_eq!(controller.queued(), 0);

--- a/src/reflex.rs
+++ b/src/reflex.rs
@@ -1,10 +1,12 @@
-//! Realtime reflex control for two-speed agents.
+//! Bounded reflex arbitration. Stop controls never compete with the data queue.
 //!
-//! The reflex path can acknowledge, pause, cancel, and forward events, but it
-//! cannot authorize external effects. Privileged actions remain behind RVM and
-//! the deliberative reasoning path.
+//! One controller belongs to one authenticated session. Source sequence numbers
+//! are monotonic; caller timestamps are telemetry, not authorization. Receipts
+//! request local control only. RVM remains the external effect boundary.
 
 use std::collections::VecDeque;
+
+const MAX_QUEUE: usize = 4096;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ReflexEventKind {
@@ -13,6 +15,18 @@ pub enum ReflexEventKind {
     Cancel,
     Observation,
     CommitBoundary,
+}
+
+impl ReflexEventKind {
+    fn wire_name(self) -> &'static str {
+        match self {
+            Self::Interrupt => "Interrupt",
+            Self::Backchannel => "Backchannel",
+            Self::Cancel => "Cancel",
+            Self::Observation => "Observation",
+            Self::CommitBoundary => "CommitBoundary",
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -63,6 +77,8 @@ pub enum ReflexDisposition {
     Stale,
     Coalesced,
     Overflow,
+    /// Control accepted in its dedicated latch while the data queue was full.
+    Priority,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -72,6 +88,7 @@ pub struct ReflexReceipt {
     pub actions: ReflexActions,
     pub authority: &'static str,
     pub queued: usize,
+    /// Estimated obsolete work, not proof that a remote provider stopped.
     pub cancelled_work_units: u64,
 }
 
@@ -80,7 +97,49 @@ pub struct ReasonerHandoff {
     pub latest_sequence: u64,
     pub queued_events: Vec<ReflexEvent>,
     pub cancelled_work_units: u64,
+    pub interrupt_sequence: Option<u64>,
+    pub cancel_sequence: Option<u64>,
+    pub dropped_events: u64,
     pub authority: &'static str,
+}
+
+impl ReasonerHandoff {
+    /// Versioned JSON bridge. All u64 values use decimal strings to avoid loss
+    /// above JavaScript's 53-bit integer range. Call only on authenticated IPC.
+    pub fn to_wire_json(&self, session_id: &str) -> Result<String, &'static str> {
+        if session_id.is_empty()
+            || session_id.len() > 128
+            || !session_id
+                .bytes()
+                .all(|c| c.is_ascii_alphanumeric() || b"._:".contains(&c))
+        {
+            return Err("invalid session identity");
+        }
+        if self.authority != "none" || self.queued_events.len() > MAX_QUEUE {
+            return Err("invalid handoff");
+        }
+        let events = self
+            .queued_events
+            .iter()
+            .map(|event| {
+                format!(
+                    "{{\"sequence\":\"{}\",\"at_micros\":\"{}\",\"kind\":\"{}\"}}",
+                    event.sequence,
+                    event.at_micros,
+                    event.kind.wire_name()
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(",");
+        let latch = |value: Option<u64>| {
+            value.map_or_else(|| "null".to_string(), |v| format!("\"{v}\""))
+        };
+        Ok(format!(
+            "{{\"version\":1,\"authority\":\"none\",\"session_id\":\"{}\",\"latest_sequence\":\"{}\",\"queued_events\":[{}],\"interrupt_sequence\":{},\"cancel_sequence\":{},\"cancelled_work_units\":\"{}\",\"dropped_events\":\"{}\"}}",
+            session_id, self.latest_sequence, events, latch(self.interrupt_sequence),
+            latch(self.cancel_sequence), self.cancelled_work_units, self.dropped_events
+        ))
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -89,18 +148,31 @@ pub struct ReflexController {
     latest_sequence: u64,
     queue: VecDeque<ReflexEvent>,
     cancelled_work_units: u64,
-    last_interrupt_sequence: Option<u64>,
+    interrupt_sequence: Option<u64>,
+    cancel_sequence: Option<u64>,
+    dropped_events: u64,
+    cancellation_accounted: bool,
 }
 
 impl ReflexController {
+    /// Preallocates once. Legacy constructor bounds invalid capacities to 1..4096.
     pub fn new(max_queue: usize) -> Self {
+        let max_queue = max_queue.clamp(1, MAX_QUEUE);
         Self {
-            max_queue: max_queue.max(1),
+            max_queue,
             latest_sequence: 0,
-            queue: VecDeque::new(),
+            queue: VecDeque::with_capacity(max_queue),
             cancelled_work_units: 0,
-            last_interrupt_sequence: None,
+            interrupt_sequence: None,
+            cancel_sequence: None,
+            dropped_events: 0,
+            cancellation_accounted: false,
         }
+    }
+
+    /// Called by the trusted host only after the preceding generation is quiescent.
+    pub fn begin_reasoning(&mut self) {
+        self.cancellation_accounted = false;
     }
 
     pub fn observe(&mut self, event: ReflexEvent, in_flight_work_units: u64) -> ReflexReceipt {
@@ -111,58 +183,68 @@ impl ReflexController {
                 ReflexActions::one(ReflexAction::Noop),
             );
         }
-
         self.latest_sequence = event.sequence;
-
-        if event.kind == ReflexEventKind::Interrupt
-            && self
-                .last_interrupt_sequence
-                .is_some_and(|previous| event.sequence == previous + 1)
-        {
-            self.last_interrupt_sequence = Some(event.sequence);
-            return self.receipt(
-                event.sequence,
-                ReflexDisposition::Coalesced,
-                ReflexActions::two(ReflexAction::Acknowledge, ReflexAction::PauseReasoning),
-            );
+        let control = matches!(
+            event.kind,
+            ReflexEventKind::Interrupt | ReflexEventKind::Cancel
+        );
+        // Apply controls BEFORE bounded data admission. These latches survive drain.
+        let actions = match event.kind {
+            ReflexEventKind::Interrupt => {
+                self.interrupt_sequence = Some(event.sequence);
+                ReflexActions::two(ReflexAction::Acknowledge, ReflexAction::PauseReasoning)
+            }
+            ReflexEventKind::Cancel => {
+                self.cancel_sequence = Some(event.sequence);
+                ReflexActions::two(ReflexAction::Acknowledge, ReflexAction::RequestCancel)
+            }
+            ReflexEventKind::Backchannel => ReflexActions::one(ReflexAction::Acknowledge),
+            ReflexEventKind::Observation | ReflexEventKind::CommitBoundary => {
+                ReflexActions::one(ReflexAction::ForwardToReasoner)
+            }
+        };
+        if control && !self.cancellation_accounted {
+            self.cancelled_work_units = self
+                .cancelled_work_units
+                .saturating_add(in_flight_work_units);
+            self.cancellation_accounted = true;
         }
-
-        if self.queue.len() >= self.max_queue {
+        // Only replace a still-pending adjacent interrupt, never one already drained.
+        if event.kind == ReflexEventKind::Interrupt {
+            if let Some(tail) = self.queue.back_mut() {
+                if tail.kind == ReflexEventKind::Interrupt
+                    && tail.sequence.checked_add(1) == Some(event.sequence)
+                {
+                    let sequence = event.sequence;
+                    *tail = event;
+                    return self.receipt(sequence, ReflexDisposition::Coalesced, actions);
+                }
+            }
+        }
+        if self.queue.len() == self.max_queue {
+            if control {
+                return self.receipt(event.sequence, ReflexDisposition::Priority, actions);
+            }
+            self.dropped_events = self.dropped_events.saturating_add(1);
             return self.receipt(
                 event.sequence,
                 ReflexDisposition::Overflow,
                 ReflexActions::one(ReflexAction::Noop),
             );
         }
-
-        let actions = match event.kind {
-            ReflexEventKind::Interrupt => {
-                self.last_interrupt_sequence = Some(event.sequence);
-                ReflexActions::two(ReflexAction::Acknowledge, ReflexAction::PauseReasoning)
-            }
-            ReflexEventKind::Backchannel => ReflexActions::one(ReflexAction::Acknowledge),
-            ReflexEventKind::Cancel => {
-                self.cancelled_work_units = self
-                    .cancelled_work_units
-                    .saturating_add(in_flight_work_units);
-                ReflexActions::two(ReflexAction::Acknowledge, ReflexAction::RequestCancel)
-            }
-            ReflexEventKind::Observation | ReflexEventKind::CommitBoundary => {
-                ReflexActions::one(ReflexAction::ForwardToReasoner)
-            }
-        };
-
         let sequence = event.sequence;
         self.queue.push_back(event);
         self.receipt(sequence, ReflexDisposition::Accepted, actions)
     }
 
     pub fn drain_for_reasoner(&mut self) -> ReasonerHandoff {
-        let queued_events = self.queue.drain(..).collect();
         ReasonerHandoff {
             latest_sequence: self.latest_sequence,
-            queued_events,
+            queued_events: self.queue.drain(..).collect(),
             cancelled_work_units: self.cancelled_work_units,
+            interrupt_sequence: self.interrupt_sequence,
+            cancel_sequence: self.cancel_sequence,
+            dropped_events: self.dropped_events,
             authority: "none",
         }
     }
@@ -195,74 +277,174 @@ mod tests {
     fn event(sequence: u64, kind: ReflexEventKind) -> ReflexEvent {
         ReflexEvent {
             sequence,
-            at_micros: sequence * 100,
+            at_micros: sequence,
             kind,
         }
     }
 
     #[test]
     fn interrupt_acknowledges_without_authority() {
-        let mut controller = ReflexController::new(8);
-        let receipt = controller.observe(event(1, ReflexEventKind::Interrupt), 12);
-        assert_eq!(receipt.disposition, ReflexDisposition::Accepted);
-        assert_eq!(receipt.authority, "none");
-        assert_eq!(
-            receipt.actions,
-            ReflexActions::two(ReflexAction::Acknowledge, ReflexAction::PauseReasoning)
-        );
+        let r = ReflexController::new(8).observe(event(1, ReflexEventKind::Interrupt), 12);
+        assert_eq!(r.authority, "none");
+        assert!(r.actions.contains(ReflexAction::PauseReasoning));
     }
 
     #[test]
     fn stale_events_fail_closed() {
-        let mut controller = ReflexController::new(8);
-        controller.observe(event(2, ReflexEventKind::Observation), 0);
-        let stale = controller.observe(event(1, ReflexEventKind::Cancel), 50);
-        assert_eq!(stale.disposition, ReflexDisposition::Stale);
-        assert_eq!(stale.cancelled_work_units, 0);
-    }
-
-    #[test]
-    fn adjacent_interrupts_coalesce() {
-        let mut controller = ReflexController::new(8);
-        controller.observe(event(1, ReflexEventKind::Interrupt), 0);
-        let second = controller.observe(event(2, ReflexEventKind::Interrupt), 0);
-        assert_eq!(second.disposition, ReflexDisposition::Coalesced);
-        assert_eq!(controller.queued(), 1);
-    }
-
-    #[test]
-    fn cancellation_accounts_wasted_work() {
-        let mut controller = ReflexController::new(8);
-        let receipt = controller.observe(event(1, ReflexEventKind::Cancel), 7);
-        assert_eq!(receipt.cancelled_work_units, 7);
-        assert!(receipt.actions.contains(ReflexAction::RequestCancel));
-    }
-
-    #[test]
-    fn queue_overflow_does_not_expand_state() {
-        let mut controller = ReflexController::new(1);
-        controller.observe(event(1, ReflexEventKind::Observation), 0);
-        let overflow = controller.observe(event(2, ReflexEventKind::Backchannel), 0);
-        assert_eq!(overflow.disposition, ReflexDisposition::Overflow);
-        assert_eq!(controller.queued(), 1);
-    }
-
-    #[test]
-    fn handoff_preserves_event_order_and_has_no_authority() {
-        let mut controller = ReflexController::new(8);
-        controller.observe(event(1, ReflexEventKind::Observation), 0);
-        controller.observe(event(2, ReflexEventKind::Cancel), 3);
-        let handoff = controller.drain_for_reasoner();
-        assert_eq!(handoff.authority, "none");
-        assert_eq!(handoff.cancelled_work_units, 3);
+        let mut c = ReflexController::new(8);
+        c.observe(event(2, ReflexEventKind::Observation), 0);
         assert_eq!(
-            handoff
-                .queued_events
-                .iter()
-                .map(|event| event.sequence)
-                .collect::<Vec<_>>(),
+            c.observe(event(1, ReflexEventKind::Cancel), 50).disposition,
+            ReflexDisposition::Stale
+        );
+        assert_eq!(c.drain_for_reasoner().cancel_sequence, None);
+    }
+
+    #[test]
+    fn adjacent_interrupts_coalesce_to_latest_pending_event() {
+        let mut c = ReflexController::new(8);
+        c.observe(event(1, ReflexEventKind::Interrupt), 0);
+        assert_eq!(
+            c.observe(event(2, ReflexEventKind::Interrupt), 0).disposition,
+            ReflexDisposition::Coalesced
+        );
+        let h = c.drain_for_reasoner();
+        assert_eq!(h.queued_events.len(), 1);
+        assert_eq!(h.queued_events[0].sequence, 2);
+    }
+
+    #[test]
+    fn cancellation_is_accounted_once_per_generation() {
+        let mut c = ReflexController::new(8);
+        c.observe(event(1, ReflexEventKind::Cancel), 7);
+        assert_eq!(
+            c.observe(event(2, ReflexEventKind::Cancel), 7)
+                .cancelled_work_units,
+            7
+        );
+        c.begin_reasoning();
+        assert_eq!(
+            c.observe(event(3, ReflexEventKind::Cancel), 2)
+                .cancelled_work_units,
+            9
+        );
+    }
+
+    #[test]
+    fn queue_overflow_is_explicit_and_bounded() {
+        let mut c = ReflexController::new(1);
+        c.observe(event(1, ReflexEventKind::Observation), 0);
+        assert_eq!(
+            c.observe(event(2, ReflexEventKind::Backchannel), 0)
+                .disposition,
+            ReflexDisposition::Overflow
+        );
+        assert_eq!(c.queued(), 1);
+        assert_eq!(c.drain_for_reasoner().dropped_events, 1);
+    }
+
+    #[test]
+    fn handoff_preserves_event_order() {
+        let mut c = ReflexController::new(8);
+        c.observe(event(1, ReflexEventKind::Observation), 0);
+        c.observe(event(2, ReflexEventKind::Cancel), 3);
+        let h = c.drain_for_reasoner();
+        assert_eq!(
+            h.queued_events.iter().map(|e| e.sequence).collect::<Vec<_>>(),
             vec![1, 2]
         );
-        assert_eq!(controller.queued(), 0);
+        assert_eq!(h.authority, "none");
+        assert_eq!(c.queued(), 0);
+    }
+
+    #[test]
+    fn saturated_queue_never_loses_cancel() {
+        let mut c = ReflexController::new(1);
+        c.observe(event(1, ReflexEventKind::Observation), 0);
+        let r = c.observe(event(2, ReflexEventKind::Cancel), 9);
+        assert_eq!(r.disposition, ReflexDisposition::Priority);
+        assert!(r.actions.contains(ReflexAction::RequestCancel));
+        let h = c.drain_for_reasoner();
+        assert_eq!(h.cancel_sequence, Some(2));
+        assert_eq!(h.dropped_events, 0);
+    }
+
+    #[test]
+    fn saturated_queue_never_loses_interrupt() {
+        let mut c = ReflexController::new(1);
+        c.observe(event(1, ReflexEventKind::Observation), 0);
+        let r = c.observe(event(2, ReflexEventKind::Interrupt), 9);
+        assert!(r.actions.contains(ReflexAction::PauseReasoning));
+        assert_eq!(c.drain_for_reasoner().interrupt_sequence, Some(2));
+    }
+
+    #[test]
+    fn draining_does_not_coalesce_future_interrupts() {
+        let mut c = ReflexController::new(1);
+        c.observe(event(1, ReflexEventKind::Interrupt), 0);
+        c.drain_for_reasoner();
+        assert_eq!(
+            c.observe(event(2, ReflexEventKind::Interrupt), 0).disposition,
+            ReflexDisposition::Accepted
+        );
+        assert_eq!(c.queued(), 1);
+    }
+
+    #[test]
+    fn u64_boundary_does_not_wrap() {
+        let mut c = ReflexController::new(2);
+        c.observe(event(u64::MAX - 1, ReflexEventKind::Interrupt), 0);
+        c.observe(event(u64::MAX, ReflexEventKind::Interrupt), 0);
+        assert_eq!(
+            c.observe(event(0, ReflexEventKind::Cancel), 0).disposition,
+            ReflexDisposition::Stale
+        );
+        assert_eq!(c.drain_for_reasoner().interrupt_sequence, Some(u64::MAX));
+    }
+
+    #[test]
+    fn invalid_capacity_is_hard_bounded() {
+        let mut c = ReflexController::new(usize::MAX);
+        for n in 1..=5000 {
+            c.observe(event(n, ReflexEventKind::Observation), 0);
+        }
+        assert_eq!(c.queued(), MAX_QUEUE);
+        assert_eq!(c.drain_for_reasoner().dropped_events, 904);
+    }
+
+    #[test]
+    fn saturated_burst_preserves_both_controls() {
+        let mut c = ReflexController::new(1);
+        c.observe(event(1, ReflexEventKind::Observation), 0);
+        for n in 2..=1001 {
+            let kind = if n % 2 == 0 {
+                ReflexEventKind::Interrupt
+            } else {
+                ReflexEventKind::Cancel
+            };
+            c.observe(event(n, kind), 8);
+        }
+        let h = c.drain_for_reasoner();
+        assert_eq!(h.interrupt_sequence, Some(1000));
+        assert_eq!(h.cancel_sequence, Some(1001));
+        assert_eq!(h.cancelled_work_units, 8);
+        assert_eq!(h.queued_events.len(), 1);
+    }
+
+    #[test]
+    fn wire_is_versioned_and_uses_decimal_strings() {
+        let mut c = ReflexController::new(1);
+        c.observe(event(1, ReflexEventKind::Observation), 0);
+        c.observe(event(2, ReflexEventKind::Cancel), 8);
+        let wire = c.drain_for_reasoner().to_wire_json("s").unwrap();
+        assert_eq!(wire, "{\"version\":1,\"authority\":\"none\",\"session_id\":\"s\",\"latest_sequence\":\"2\",\"queued_events\":[{\"sequence\":\"1\",\"at_micros\":\"1\",\"kind\":\"Observation\"}],\"interrupt_sequence\":null,\"cancel_sequence\":\"2\",\"cancelled_work_units\":\"8\",\"dropped_events\":\"0\"}");
+    }
+
+    #[test]
+    fn wire_rejects_session_injection() {
+        let h = ReflexController::new(1).drain_for_reasoner();
+        for s in ["", "../other", "x\"", "a\nb"] {
+            assert!(h.to_wire_json(s).is_err());
+        }
     }
 }


### PR DESCRIPTION
Tracks #106, ruvnet/ruflo#3248, and ruvnet/metaharness#301 Track D / PR #302.

## Implemented and hardened

The bounded Rust reflex controller handles acknowledgement, interrupt, cancellation and ordered evidence handoff without model calls or external-effect authority. Fixed two-slot actions and one preallocated bounded queue avoid per-event action-vector allocation.

The continuation found and fixed two real control defects: cancellation could be dropped when the data queue was full, and an interrupt could coalesce against an event already drained. Dedicated persistent control latches now run before queue admission. Only still-pending adjacent interrupts coalesce. Estimated obsolete work is counted once per explicitly started reasoning generation. Data loss is recorded separately.

The versioned wire bridge uses canonical decimal strings for u64 values, including values above JavaScript's safe integer range. Session identities are bounded and validated. Authenticated transport remains the host's responsibility. Receipts carry authority:none and do not authorize external effects.

## Executed validation

14 Rust tests pass both standalone and through the actual root midstream library. Added direct root validation because the existing workspace matrix excluded the root module. Locked root build, strict Clippy and Criterion benchmark compilation pass. Seven preexisting format-string lint instances exposed by the new gate were corrected without weakening lint policy.

MetaHarness run34358153288 executed the actual Rust controller and actual Ruflo bridge across1000 saturated-queue sessions. All1000 cancellations succeeded and all1000 late outputs were suppressed, including high-precision sequences and u64::MAX. Ruflo's30 contract tests include real HTTP stream teardown, delegated work, asynchronous tool-approval races, malformed inputs, limits, stale outputs and uncooperative cancellation.

Criterion compilation is not a measured Rust hot-path benchmark result. The reported latency experiment is the separately documented randomized asynchronous control workload, not live-model quality.

## Dependency review and exact release state

The committed Cargo.lock still triggers existing advisories. A read-only repair workflow produced an exact proposed manifest/lockfile patch and successfully ran cargo audit, Rust1.88 workspace checks, workspace library/integration tests and strict root Clippy. Audit vulnerabilities fell from3 to0; one existing unmaintained paste warning remains. The generated lockfile resolves lru0.18.4, crossbeam-epoch0.9.20, h20.4.16, quinn-proto0.11.15 and anyhow1.0.104.

Repair evidence: https://github.com/ruvnet/midstream/actions/runs/34359588605
Artifact name: reflex-dependency-repair. Archive SHA256: 8e3be4538ee766b0821384f125c4232e8956738a6e633b80bad55d32350869f1.

These generated dependency changes are NOT yet applied to this branch. Therefore the existing supply-chain gate remains red. The repair workflow has read-only repository credentials and cannot commit, push or merge. No advisory or security threshold was waived.

## Remaining acceptance

Apply and review the generated dependency patch and rerun the full platform/security matrix on that exact resulting commit. Independently qualify real provider quality within2 percentage points and cancellation waste below10%; local connection closure does not attest remote GPU shutdown or billing. The implementation is opt-in and does not change current production routing.

Keep draft. No autonomous merge, deployment, credential escalation or irreversible migration.